### PR TITLE
Added check to ensure that window can be maximized before maximizing …

### DIFF
--- a/Applications/spire/source/ui/title_bar.cpp
+++ b/Applications/spire/source/ui/title_bar.cpp
@@ -188,10 +188,12 @@ bool title_bar::eventFilter(QObject* watched, QEvent* event) {
 }
 
 void title_bar::mouseDoubleClickEvent(QMouseEvent* event) {
-  if(window()->isMaximized()) {
-    on_restore_button_press();
-  } else {
-    on_maximize_button_press();
+  if(window()->windowFlags().testFlag(Qt::WindowMaximizeButtonHint)) {
+    if(window()->isMaximized()) {
+      on_restore_button_press();
+    } else {
+      on_maximize_button_press();
+    }
   }
 }
 


### PR DESCRIPTION
I put the build in the misc_builds Dropbox folder.

You can compare this branch's build with fb1107's build in the same folder to see the difference. In the fb1107 build the properties window will maximize.