### PR TITLE
Added check to ensure data is being loaded before showing transition …

### DIFF
--- a/Applications/spire/source/time_and_sales/time_and_sales_table_view.cpp
+++ b/Applications/spire/source/time_and_sales/time_and_sales_table_view.cpp
@@ -166,7 +166,7 @@ void TimeAndSalesTableView::set_properties(
 }
 
 void TimeAndSalesTableView::show_transition_widget() {
-  if(m_table->model()->rowCount(QModelIndex()) == 0) {
+  if(m_table->model()->rowCount(QModelIndex()) == 0 && m_model->is_loading()) {
     m_transition_widget = std::make_unique<TransitionWidget>(this);
   }
 }

--- a/Applications/spire/source/time_and_sales_ui_tester/time_and_sales_test_controller_window.cpp
+++ b/Applications/spire/source/time_and_sales_ui_tester/time_and_sales_test_controller_window.cpp
@@ -99,8 +99,10 @@ void TimeAndSalesTestControllerWindow::update_data_loaded_check_box() {
 }
 
 void TimeAndSalesTestControllerWindow::update_loading_time() {
-  m_model->set_load_duration(boost::posix_time::milliseconds(
-    m_loading_time_spin_box->value()));
+  if(!m_all_data_loaded_check_box->isChecked()) {
+    m_model->set_load_duration(boost::posix_time::milliseconds(
+      m_loading_time_spin_box->value()));
+  }
 }
 
 void TimeAndSalesTestControllerWindow::update_price(double price) {


### PR DESCRIPTION
I updated the build on Dropbox.

Now when the 'All Data Loaded' checkbox is checked before selecting a new security the transition widget doesn't show.