### PR TITLE
Fixed hover style issues with IconButton

### DIFF
--- a/Applications/spire/include/spire/ui/icon_button.hpp
+++ b/Applications/spire/include/spire/ui/icon_button.hpp
@@ -70,11 +70,12 @@ namespace Spire {
         const ClickedSignal::slot_type& slot) const;
 
     protected:
-      void enterEvent(QEvent* event) override;
       void focusInEvent(QFocusEvent* event) override;
       void focusOutEvent(QFocusEvent* event) override;
+      void hideEvent(QHideEvent* event) override;
       void keyPressEvent(QKeyEvent* event) override;
       void leaveEvent(QEvent* event) override;
+      void mouseMoveEvent(QMouseEvent* event) override;
       void mousePressEvent(QMouseEvent* event) override;
       void mouseReleaseEvent(QMouseEvent* event) override;
       void paintEvent(QPaintEvent* event) override;

--- a/Applications/spire/source/ui/icon_button.cpp
+++ b/Applications/spire/source/ui/icon_button.cpp
@@ -21,6 +21,7 @@ IconButton::IconButton(QImage icon, QImage hover_icon,
       m_hover_icon(std::move(hover_icon)),
       m_blur_icon(std::move(blur_icon)) {
   setFocusPolicy(Qt::StrongFocus);
+  setMouseTracking(true);
   auto layout = new QHBoxLayout(this);
   layout->setContentsMargins({});
   setFixedSize(m_icon.size());
@@ -60,17 +61,6 @@ connection IconButton::connect_clicked_signal(
   return m_clicked_signal.connect(slot);
 }
 
-void IconButton::enterEvent(QEvent* event) {
-  if(isEnabled()) {
-    switch(m_state) {
-      case State::NORMAL:
-        return show_hovered();
-      case State::BLURRED:
-        return show_hover_blurred();
-    }
-  }
-}
-
 void IconButton::focusInEvent(QFocusEvent* event) {
   if(focusPolicy() & Qt::TabFocus) {
     switch(m_state) {
@@ -93,6 +83,12 @@ void IconButton::focusOutEvent(QFocusEvent* event) {
   }
 }
 
+void IconButton::hideEvent(QHideEvent* event) {
+  if(m_state == State::HOVERED) {
+    show_normal();
+  }
+}
+
 void IconButton::keyPressEvent(QKeyEvent* event) {
   if(event->key() == Qt::Key_Enter || event->key() == Qt::Key_Return ||
       event->key() == Qt::Key_Space) {
@@ -109,6 +105,18 @@ void IconButton::leaveEvent(QEvent* event) {
       return show_normal();
     case State::HOVER_BLURRED:
       return show_blurred();
+  }
+}
+
+void IconButton::mouseMoveEvent(QMouseEvent* event) {
+  if(isEnabled() && m_state != State::BLURRED &&
+      m_state != State::HOVER_BLURRED) {
+    switch(m_state) {
+      case State::NORMAL:
+        return show_hovered();
+      case State::BLURRED:
+        return show_hover_blurred();
+    }
   }
 }
 


### PR DESCRIPTION
I updated all builds so you can test any of them.

The hideEvent() fixes the initial issue [documented](https://eidolonsystems.fogbugz.com/f/cases/1062/Mouse-Hover-Events) in the case and the mouseMoveEvent() is the fix for the new issue (also documented).