### PR TITLE
Min max size window

### DIFF
--- a/Applications/Spire/Include/Spire/Ui/Window.hpp
+++ b/Applications/Spire/Include/Spire/Ui/Window.hpp
@@ -62,6 +62,8 @@ namespace Spire {
       */
       void set_fixed_body_size(const QSize& size);
 
+      void set_maximizeable(bool is_maximizeable);
+
       void changeEvent(QEvent* event) override;
       void closeEvent(QCloseEvent* event) override;
       bool event(QEvent* event) override;
@@ -73,8 +75,9 @@ namespace Spire {
       TitleBar* m_title_bar;
       int m_resize_area_width;
       bool m_is_resizeable;
+      bool m_is_maximizeable;
 
-      void set_resizeable(bool resizeable);
+      void set_window_attributes(bool is_resizeable, bool is_maximizeable);
   };
 }
 

--- a/Applications/Spire/Include/Spire/Ui/Window.hpp
+++ b/Applications/Spire/Include/Spire/Ui/Window.hpp
@@ -62,13 +62,6 @@ namespace Spire {
       */
       void set_fixed_body_size(const QSize& size);
 
-      //! Sets whether the window can be maximized.
-      /*
-        \param is_maximizeable True if the window can be maximized, false
-                               otherwise.
-      */
-      void set_maximizeable(bool is_maximizeable);
-
       void changeEvent(QEvent* event) override;
       void closeEvent(QCloseEvent* event) override;
       bool event(QEvent* event) override;
@@ -80,9 +73,8 @@ namespace Spire {
       TitleBar* m_title_bar;
       int m_resize_area_width;
       bool m_is_resizeable;
-      bool m_is_maximizeable;
 
-      void set_window_attributes(bool is_resizeable, bool is_maximizeable);
+      void set_window_attributes(bool is_resizeable);
   };
 }
 

--- a/Applications/Spire/Include/Spire/Ui/Window.hpp
+++ b/Applications/Spire/Include/Spire/Ui/Window.hpp
@@ -62,7 +62,7 @@ namespace Spire {
       */
       void set_fixed_body_size(const QSize& size);
 
-      //! Sets the whether the window can be maximized.
+      //! Sets whether the window can be maximized.
       /*
         \param is_maximizeable True if the window can be maximized, false
                                otherwise.

--- a/Applications/Spire/Include/Spire/Ui/Window.hpp
+++ b/Applications/Spire/Include/Spire/Ui/Window.hpp
@@ -62,6 +62,11 @@ namespace Spire {
       */
       void set_fixed_body_size(const QSize& size);
 
+      //! Sets the whether the window can be maximized.
+      /*
+        \param is_maximizeable True if the window can be maximized, false
+                               otherwise.
+      */
       void set_maximizeable(bool is_maximizeable);
 
       void changeEvent(QEvent* event) override;

--- a/Applications/Spire/Source/Ui/Window.cpp
+++ b/Applications/Spire/Source/Ui/Window.cpp
@@ -74,7 +74,7 @@ void Window::closeEvent(QCloseEvent* event) {
 
 bool Window::event(QEvent* event) {
   if(event->type() == QEvent::WinIdChange) {
-    set_window_attributes(m_is_resizeable, m_is_maximizeable);
+    set_window_attributes(m_is_resizeable);
   }
   return QWidget::event(event);
 }
@@ -167,19 +167,14 @@ void Window::resize_body(const QSize& size) {
 }
 
 void Window::set_fixed_body_size(const QSize& size) {
-  set_window_attributes(false, false);
+  set_window_attributes(false);
   setFixedSize({size.width(), size.height() + m_title_bar->height()});
 }
 
-void Window::set_maximizeable(bool is_maximizeable) {
-  m_is_maximizeable = is_maximizeable;
-  set_window_attributes(m_is_resizeable, m_is_maximizeable);
-}
-
-void Window::set_window_attributes(bool is_resizeable, bool is_maximizeable) {
+void Window::set_window_attributes(bool is_resizeable) {
   m_is_resizeable = is_resizeable;
-  m_is_maximizeable = is_maximizeable;
-  if(m_is_resizeable && !m_is_maximizeable) {
+  if(m_is_resizeable &&
+      maximumSize() != QSize(QWIDGETSIZE_MAX, QWIDGETSIZE_MAX)) {
     setWindowFlags(windowFlags() & ~Qt::WindowMaximizeButtonHint);
     auto hwnd = reinterpret_cast<HWND>(effectiveWinId());
     ::SetWindowLong(hwnd, GWL_STYLE, ::GetWindowLong(hwnd, GWL_STYLE)

--- a/Applications/Spire/Source/Ui/Window.cpp
+++ b/Applications/Spire/Source/Ui/Window.cpp
@@ -74,7 +74,7 @@ void Window::closeEvent(QCloseEvent* event) {
 
 bool Window::event(QEvent* event) {
   if(event->type() == QEvent::WinIdChange) {
-    set_resizeable(m_is_resizeable);
+    set_window_attributes(m_is_resizeable, m_is_maximizeable);
   }
   return QWidget::event(event);
 }
@@ -167,13 +167,24 @@ void Window::resize_body(const QSize& size) {
 }
 
 void Window::set_fixed_body_size(const QSize& size) {
-  set_resizeable(false);
+  set_window_attributes(false, false);
   setFixedSize({size.width(), size.height() + m_title_bar->height()});
 }
 
-void Window::set_resizeable(bool resizeable) {
-  m_is_resizeable = resizeable;
-  if(m_is_resizeable) {
+void Window::set_maximizeable(bool is_maximizeable) {
+  m_is_maximizeable = is_maximizeable;
+  set_window_attributes(m_is_resizeable, m_is_maximizeable);
+}
+
+void Window::set_window_attributes(bool is_resizeable, bool is_maximizeable) {
+  m_is_resizeable = is_resizeable;
+  m_is_maximizeable = is_maximizeable;
+  if(m_is_resizeable && !m_is_maximizeable) {
+    setWindowFlags(windowFlags() & ~Qt::WindowMaximizeButtonHint);
+    auto hwnd = reinterpret_cast<HWND>(effectiveWinId());
+    ::SetWindowLong(hwnd, GWL_STYLE, ::GetWindowLong(hwnd, GWL_STYLE)
+      | WS_THICKFRAME | WS_CAPTION);
+  } else if(m_is_resizeable) {
     setWindowFlags(windowFlags() | Qt::WindowMaximizeButtonHint);
     auto hwnd = reinterpret_cast<HWND>(effectiveWinId());
     ::SetWindowLong(hwnd, GWL_STYLE, ::GetWindowLong(hwnd, GWL_STYLE)


### PR DESCRIPTION
I made a temporary change in the TimeAndSalesUiTester to demo this. I kept it consistent with the Qt functions, so the usage looks like:

setMinimumSize(scale(180, 200));
setMaximumSize(scale(250, 600));
resize_body(scale(180, 450)); // set initial window size
set_maximizeable(false);