### PR TITLE
Manually set MINMAXINFO to prevent forced resizing greater than maxim…

### DIFF
--- a/Applications/Spire/Source/Ui/Window.cpp
+++ b/Applications/Spire/Source/Ui/Window.cpp
@@ -158,6 +158,13 @@ bool Window::nativeEvent(const QByteArray& eventType, void* message,
     } else if(msg->wParam == SIZE_RESTORED) {
       setContentsMargins({});
     }
+  } else if(msg->message == WM_GETMINMAXINFO) {
+    auto mmi = reinterpret_cast<MINMAXINFO*>(msg->lParam);
+    mmi->ptMaxTrackSize.x = maximumSize().width();
+    mmi->ptMaxTrackSize.y = maximumSize().height();
+    mmi->ptMinTrackSize.x = minimumSize().width();
+    mmi->ptMinTrackSize.y = minimumSize().height();
+    return true;
   }
   return QWidget::nativeEvent(eventType, message, result);
 }


### PR DESCRIPTION
I put the demos in the /Spire Desktop/window_builds/ Dropbox folder. You should be able to resize, maximize, restore, drag-restore, etc. and the windows will maintain consistent/expected sizing.

I had to close the last PR because of a fairly large typo in the commit message.