### PR TITLE
Added 'phantom' WM_NCCACLSIZE message to fix window margins issue

### DIFF
--- a/Applications/Spire/Include/Spire/Ui/Window.hpp
+++ b/Applications/Spire/Include/Spire/Ui/Window.hpp
@@ -74,6 +74,7 @@ namespace Spire {
       int m_resize_area_width;
       bool m_is_resizeable;
 
+      void on_screen_changed(QScreen* screen);
       void set_window_attributes(bool is_resizeable);
   };
 }

--- a/Applications/Spire/Source/Ui/Window.cpp
+++ b/Applications/Spire/Source/Ui/Window.cpp
@@ -177,6 +177,8 @@ void Window::resize_body(const QSize& size) {
 }
 
 void Window::on_screen_changed(QScreen* screen) {
+  // TODO: Workaround for this change:
+  // https://github.com/qt/qtbase/commit/d2fd9b1b9818b3ec88487967e010f66e92952f55
   auto hwnd = reinterpret_cast<HWND>(effectiveWinId());
   auto rect = RECT{ 0, 0, 1, 1 };
   SendMessage(hwnd, WM_NCCALCSIZE, TRUE, reinterpret_cast<LPARAM>(&rect));

--- a/Applications/Spire/Source/Ui/Window.cpp
+++ b/Applications/Spire/Source/Ui/Window.cpp
@@ -3,6 +3,7 @@
 #include <QGuiApplication>
 #include <QScreen>
 #include <QVBoxLayout>
+#include <QWindow>
 #include <dwmapi.h>
 #include <qt_windows.h>
 #include <windowsx.h>
@@ -75,6 +76,8 @@ void Window::closeEvent(QCloseEvent* event) {
 bool Window::event(QEvent* event) {
   if(event->type() == QEvent::WinIdChange) {
     set_window_attributes(m_is_resizeable);
+    connect(windowHandle(), &QWindow::screenChanged, this,
+      &Window::on_screen_changed);
   }
   return QWidget::event(event);
 }
@@ -171,6 +174,12 @@ bool Window::nativeEvent(const QByteArray& eventType, void* message,
 
 void Window::resize_body(const QSize& size) {
   resize({size.width(), size.height() + m_title_bar->height()});
+}
+
+void Window::on_screen_changed(QScreen* screen) {
+  auto hwnd = reinterpret_cast<HWND>(effectiveWinId());
+  auto rect = RECT{ 0, 0, 1, 1 };
+  SendMessage(hwnd, WM_NCCALCSIZE, TRUE, reinterpret_cast<LPARAM>(&rect));
 }
 
 void Window::set_fixed_body_size(const QSize& size) {


### PR DESCRIPTION
This issue stems from a Qt fix for the window's margins when moving across monitors with DPI scaling, where they add/recalculate margins for any window that doesn't have high DPI scaling disabled. The commit message mentions only applying these margins until a WM_NCCALCSIZE (calculate non-client area for the window) message is received, so this fix just manually sends this message to the window. The rect paramter itself doesn't matter, because for our window the client size takes up the whole window anyway, so it's just to satisfy the API of the SendMessage function. Making the rect {0, 0, 0, 0} seems to make the message get ignored by Qt, though.

In on_screen_changed(), the pointer to a local variable looks suspect, but the documentation assures that SendMessage will not return until the message is processed: https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-sendmessage

The Login Window uses a different window implementation so I added both the Book View and the Login Window testers to the drafts folder.