### PR TITLE
Money input widget

### DIFF
--- a/Applications/Spire/Include/Spire/Ui/MoneyInputWidget.hpp
+++ b/Applications/Spire/Include/Spire/Ui/MoneyInputWidget.hpp
@@ -1,0 +1,47 @@
+#ifndef SPIRE_MONEY_INPUT_WIDGET_HPP
+#define SPIRE_MONEY_INPUT_WIDGET_HPP
+#include <QLineEdit>
+#include "Nexus/Definitions/Money.hpp"
+#include "Spire/Ui/CustomQtVariants.hpp"
+
+namespace Spire {
+
+  //! Displays an input box that accepts Quantities.
+  class MoneyInputWidget : public QLineEdit {
+    public:
+
+      //! Signals that the user has modified the input box or submitted a
+      //! value.
+      using InputSignal = Signal<void (Nexus::Money)>;
+
+      //! Constructs a MoneyInputWidget.
+      /*
+        \param parent The parent widget.
+      */
+      explicit MoneyInputWidget(QWidget* parent = nullptr);
+
+      //! Sets the value to display in the input box.
+      /*
+        \param value The value to display.
+      */
+      void set_value(Nexus::Money value);
+
+      //! Connects a signal to the value committed signal.
+      boost::signals2::connection connect_committed_signal(
+        const InputSignal::slot_type& slot) const;
+
+      //! Connects a signal to the value modified signal.
+      boost::signals2::connection connect_modified_signal(
+        const InputSignal::slot_type& slot) const;
+
+    private:
+      CustomVariantItemDelegate m_item_delegate;
+      mutable InputSignal m_committed_signal;
+      mutable InputSignal m_modified_signal;
+
+      void on_line_edit_committed();
+      void on_line_edit_modified(const QString& text);
+  };
+}
+
+#endif

--- a/Applications/Spire/Include/Spire/Ui/MoneyInputWidget.hpp
+++ b/Applications/Spire/Include/Spire/Ui/MoneyInputWidget.hpp
@@ -6,7 +6,7 @@
 
 namespace Spire {
 
-  //! Displays an input box that accepts Quantities.
+  //! Displays an input box that accepts Money values.
   class MoneyInputWidget : public QLineEdit {
     public:
 

--- a/Applications/Spire/Include/Spire/Ui/Ui.hpp
+++ b/Applications/Spire/Include/Spire/Ui/Ui.hpp
@@ -15,7 +15,9 @@ namespace Spire {
   class DropShadow;
   class FlatButton;
   class IconButton;
+  class MoneyInputWidget;
   class PropertiesWindowButtonsWidget;
+  class QuantityInputWidget;
   class SecurityStack;
   class SecurityWidget;
   class TitleBar;

--- a/Applications/Spire/Source/Ui/MoneyInputWidget.cpp
+++ b/Applications/Spire/Source/Ui/MoneyInputWidget.cpp
@@ -11,7 +11,7 @@ MoneyInputWidget::MoneyInputWidget(QWidget* parent)
       m_item_delegate(this) {
   apply_line_edit_style(this);
   setValidator(new QRegularExpressionValidator(
-    QRegularExpression("((\\d+\\.?\\d*)|(\\.\\d+))"), this));
+    QRegularExpression("((\\d+\\.?\\d{0,2})|(\\.\\d{0,2}))"), this));
   connect(this, &QLineEdit::editingFinished, this,
     &MoneyInputWidget::on_line_edit_committed);
   connect(this, &QLineEdit::textEdited, this,

--- a/Applications/Spire/Source/Ui/MoneyInputWidget.cpp
+++ b/Applications/Spire/Source/Ui/MoneyInputWidget.cpp
@@ -35,12 +35,18 @@ connection MoneyInputWidget::connect_modified_signal(
 
 void MoneyInputWidget::on_line_edit_committed() {
   if(!text().isEmpty()) {
-    m_committed_signal(*Money::FromValue(text().toStdString()));
+    auto value = Money::FromValue(text().toStdString());
+    if(value) {
+      m_committed_signal(*value);
+    }
   }
 }
 
 void MoneyInputWidget::on_line_edit_modified(const QString& text) {
   if(!text.isEmpty()) {
-    m_modified_signal(*Money::FromValue(text.toStdString()));
+    auto value = Money::FromValue(text.toStdString());
+    if(value) {
+      m_modified_signal(*value);
+    }
   }
 }

--- a/Applications/Spire/Source/Ui/MoneyInputWidget.cpp
+++ b/Applications/Spire/Source/Ui/MoneyInputWidget.cpp
@@ -11,7 +11,7 @@ MoneyInputWidget::MoneyInputWidget(QWidget* parent)
       m_item_delegate(this) {
   apply_line_edit_style(this);
   setValidator(new QRegularExpressionValidator(
-    QRegularExpression("((\d+\.?\d*)|(\.\d+))"), this));
+    QRegularExpression("((\\d+\\.?\\d*)|(\\.\\d+))"), this));
   connect(this, &QLineEdit::editingFinished, this,
     &MoneyInputWidget::on_line_edit_committed);
   connect(this, &QLineEdit::textEdited, this,
@@ -20,7 +20,7 @@ MoneyInputWidget::MoneyInputWidget(QWidget* parent)
 
 void MoneyInputWidget::set_value(Money value) {
   setText(m_item_delegate.displayText(
-    QVariant::fromValue(Truncate(value, 0)), QLocale()));
+    QVariant::fromValue(Round(value, 2)), QLocale()));
 }
 
 connection MoneyInputWidget::connect_committed_signal(

--- a/Applications/Spire/Source/Ui/MoneyInputWidget.cpp
+++ b/Applications/Spire/Source/Ui/MoneyInputWidget.cpp
@@ -1,0 +1,46 @@
+#include "Spire/Ui/MoneyInputWidget.hpp"
+#include <QHBoxLayout>
+#include <QRegularExpressionValidator>
+
+using namespace boost::signals2;
+using namespace Nexus;
+using namespace Spire;
+
+MoneyInputWidget::MoneyInputWidget(QWidget* parent)
+    : QLineEdit(parent),
+      m_item_delegate(this) {
+  apply_line_edit_style(this);
+  setValidator(new QRegularExpressionValidator(
+    QRegularExpression("((\d+\.?\d*)|(\.\d+))"), this));
+  connect(this, &QLineEdit::editingFinished, this,
+    &MoneyInputWidget::on_line_edit_committed);
+  connect(this, &QLineEdit::textEdited, this,
+    &MoneyInputWidget::on_line_edit_modified);
+}
+
+void MoneyInputWidget::set_value(Money value) {
+  setText(m_item_delegate.displayText(
+    QVariant::fromValue(Truncate(value, 0)), QLocale()));
+}
+
+connection MoneyInputWidget::connect_committed_signal(
+    const InputSignal::slot_type& slot) const {
+  return m_committed_signal.connect(slot);
+}
+
+connection MoneyInputWidget::connect_modified_signal(
+    const InputSignal::slot_type& slot) const {
+  return m_modified_signal.connect(slot);
+}
+
+void MoneyInputWidget::on_line_edit_committed() {
+  if(!text().isEmpty()) {
+    m_committed_signal(*Money::FromValue(text().toStdString()));
+  }
+}
+
+void MoneyInputWidget::on_line_edit_modified(const QString& text) {
+  if(!text.isEmpty()) {
+    m_modified_signal(*Money::FromValue(text.toStdString()));
+  }
+}


### PR DESCRIPTION
I put the build in the drafts folder.

I followed the implementation of Money::FromValue() when deciding what valid input was, so: '.2' and '2.' are considered valid input, becoming '0.20' and '2.00' respectively.