### PR TITLE
Dropdown focus lost

### DIFF
--- a/Applications/Spire/Source/Charting/DropDownColorPicker.cpp
+++ b/Applications/Spire/Source/Charting/DropDownColorPicker.cpp
@@ -46,6 +46,8 @@ bool DropDownColorPicker::eventFilter(QObject* watched, QEvent* event) {
   if(watched == window()) {
     if(event->type() == QEvent::Move || event->type() == QEvent::Resize) {
       move_color_picker();
+    } else if(event->type() == QEvent::MouseButtonPress) {
+      m_color_picker->hide();
     }
   }
   return QWidget::eventFilter(watched, event);

--- a/Applications/Spire/Source/Ui/DropDownMenu.cpp
+++ b/Applications/Spire/Source/Ui/DropDownMenu.cpp
@@ -64,6 +64,8 @@ bool DropDownMenu::eventFilter(QObject* watched, QEvent* event) {
       }
     } else if(event->type() == QEvent::WindowDeactivate) {
       m_menu_list->hide();
+    } else if(event->type() == QEvent::MouseButtonPress) {
+      m_menu_list->hide();
     }
   }
   return false;


### PR DESCRIPTION
Poorly named branch, but this references the 'Hide DropDownMenu List...' case on Asana.

The ChartingDropdownFocus tester in the drafts demonstrates the DropDownMenu and the ColorPicker.

The dropdowns don't close when the user interacts with the title bar which is consistent with other programs according to Darryl.