### PR TITLE
Switched DropShadow instantiation from managed to raw pointers

### DIFF
--- a/Applications/Spire/Include/Spire/Charting/DropDownColorPicker.hpp
+++ b/Applications/Spire/Include/Spire/Charting/DropDownColorPicker.hpp
@@ -44,7 +44,7 @@ namespace Spire {
       QColor m_current_color;
       QColor m_stored_color;
       bool m_has_mouse;
-      std::unique_ptr<DropShadow> m_color_picker_drop_shadow;
+      DropShadow* m_color_picker_drop_shadow;
 
       void on_color_preview(const QColor& color);
       void on_color_selected(const QColor& color);

--- a/Applications/Spire/Include/Spire/Charting/StyleDropDownMenuList.hpp
+++ b/Applications/Spire/Include/Spire/Charting/StyleDropDownMenuList.hpp
@@ -48,7 +48,7 @@ namespace Spire {
 
     private:
       mutable SelectedSignal m_selected_signal;
-      std::unique_ptr<DropShadow> m_shadow;
+      DropShadow* m_shadow;
       QWidget* m_list_widget;
       int m_highlight_index;
 

--- a/Applications/Spire/Include/Spire/Login/LoginWindow.hpp
+++ b/Applications/Spire/Include/Spire/Login/LoginWindow.hpp
@@ -76,7 +76,7 @@ namespace Spire {
       mutable LoginSignal m_login_signal;
       mutable CancelSignal m_cancel_signal;
       State m_state;
-      std::unique_ptr<DropShadow> m_shadow;
+      DropShadow* m_shadow;
       QLabel* m_logo_widget;
       QLabel* m_status_label;
       QLineEdit* m_username_line_edit;

--- a/Applications/Spire/Include/Spire/OrderImbalanceIndicator/OrderImbalanceIndicatorContextMenu.hpp
+++ b/Applications/Spire/Include/Spire/OrderImbalanceIndicator/OrderImbalanceIndicatorContextMenu.hpp
@@ -75,8 +75,8 @@ namespace Spire {
       mutable ToggledSignal m_time_signal;
       mutable ToggledSignal m_notional_value_signal;
       QMenu* m_table_columns_menu;
-      std::unique_ptr<DropShadow> m_drop_shadow;
-      std::unique_ptr<DropShadow> m_sub_menu_drop_shadow;
+      DropShadow* m_drop_shadow;
+      DropShadow* m_sub_menu_drop_shadow;
 
       void add_check_box(const QString& text, ToggledSignal& signal);
       void add_menu_item(const QString& text, SelectedSignal& signal);

--- a/Applications/Spire/Include/Spire/SecurityInput/SecurityInfoListView.hpp
+++ b/Applications/Spire/Include/Spire/SecurityInput/SecurityInfoListView.hpp
@@ -50,7 +50,7 @@ namespace Spire {
     private:
       mutable ActivateSignal m_activate_signal;
       mutable CommitSignal m_commit_signal;
-      std::unique_ptr<DropShadow> m_shadow;
+      DropShadow* m_shadow;
       QScrollArea* m_scroll_area;
       QWidget* m_list_widget;
       QWidget* m_key_widget;

--- a/Applications/Spire/Include/Spire/SecurityInput/SecurityInputDialog.hpp
+++ b/Applications/Spire/Include/Spire/SecurityInput/SecurityInputDialog.hpp
@@ -52,7 +52,7 @@ namespace Spire {
     private:
       Nexus::Security m_security;
       SecurityInputModel* m_model;
-      std::unique_ptr<DropShadow> m_shadow;
+      DropShadow* m_shadow;
       QVBoxLayout* m_layout;
       SecurityInputBox* m_security_input_box;
       QString m_initial_text;

--- a/Applications/Spire/Include/Spire/Toolbar/ToolbarMenu.hpp
+++ b/Applications/Spire/Include/Spire/Toolbar/ToolbarMenu.hpp
@@ -62,7 +62,7 @@ namespace Spire {
       QWidgetAction* m_empty_item;
       std::unordered_map<QAction*, int> m_action_to_index;
       bool m_empty_style;
-      std::unique_ptr<DropShadow> m_drop_shadow;
+      DropShadow* m_drop_shadow;
 
       void remove_empty_item();
       void set_empty_menu_stylesheet();

--- a/Applications/Spire/Include/Spire/Ui/DateInputWidget.hpp
+++ b/Applications/Spire/Include/Spire/Ui/DateInputWidget.hpp
@@ -27,7 +27,7 @@ namespace Spire {
 
     private:
       CalendarWidget* m_calendar_widget;
-      std::unique_ptr<DropShadow> m_drop_shadow;
+      DropShadow* m_drop_shadow;
 
       void move_calendar();
       void set_default_style();

--- a/Applications/Spire/Include/Spire/Ui/DropDownMenuList.hpp
+++ b/Applications/Spire/Include/Spire/Ui/DropDownMenuList.hpp
@@ -49,7 +49,7 @@ namespace Spire {
 
     private:
       mutable SelectedSignal m_selected_signal;
-      std::unique_ptr<DropShadow> m_shadow;
+      DropShadow* m_shadow;
       QScrollArea* m_scroll_area;
       QWidget* m_list_widget;
       int m_highlight_index;

--- a/Applications/Spire/Include/Spire/Ui/DropShadow.hpp
+++ b/Applications/Spire/Include/Spire/Ui/DropShadow.hpp
@@ -6,7 +6,8 @@
 
 namespace Spire {
 
-  //! Paints a drop shadow around its parent widget.
+  //! Paints a drop shadow around its parent widget. The drop shadow instance
+  //! is deleted when its parent is deleted.
   class DropShadow : public QWidget, public QAbstractNativeEventFilter {
     public:
 

--- a/Applications/Spire/Include/Spire/Ui/DropShadow.hpp
+++ b/Applications/Spire/Include/Spire/Ui/DropShadow.hpp
@@ -6,8 +6,7 @@
 
 namespace Spire {
 
-  //! Paints a drop shadow around its parent widget. The drop shadow instance
-  //! is deleted when its parent is deleted.
+  //! Paints a drop shadow around its parent widget.
   class DropShadow : public QWidget, public QAbstractNativeEventFilter {
     public:
 

--- a/Applications/Spire/Source/Charting/DropDownColorPicker.cpp
+++ b/Applications/Spire/Source/Charting/DropDownColorPicker.cpp
@@ -31,8 +31,7 @@ DropDownColorPicker::DropDownColorPicker(QWidget* parent)
     [=] (auto& color) { on_color_preview(color); });
   m_color_picker->setFixedSize(scale(70, 70));
   m_color_picker->hide();
-  m_color_picker_drop_shadow = std::make_unique<DropShadow>(true, true,
-    m_color_picker);
+  m_color_picker_drop_shadow = new DropShadow(true, true, m_color_picker);
 }
 
 connection DropDownColorPicker::connect_color_signal(

--- a/Applications/Spire/Source/Charting/StyleDropDownMenuList.cpp
+++ b/Applications/Spire/Source/Charting/StyleDropDownMenuList.cpp
@@ -12,7 +12,7 @@ StyleDropDownMenuList::StyleDropDownMenuList(QWidget* parent)
     : QWidget(parent, Qt::Tool | Qt::FramelessWindowHint),
       m_highlight_index(-1) {
   setAttribute(Qt::WA_ShowWithoutActivating);
-  m_shadow = std::make_unique<DropShadow>(true, true, this);
+  m_shadow = new DropShadow(true, true, this);
   setStyleSheet("background-color: #A0A0A0;");
   setFixedHeight(scale_height(121));
   auto layout = new QVBoxLayout(this);

--- a/Applications/Spire/Source/Login/LoginWindow.cpp
+++ b/Applications/Spire/Source/Login/LoginWindow.cpp
@@ -17,7 +17,7 @@ LoginWindow::LoginWindow(const std::string& version, QWidget* parent)
       m_is_dragging(false) {
   setWindowIcon(QIcon(":/Icons/spire-icon-256x256.png"));
   setFixedSize(scale(396, 358));
-  m_shadow = std::make_unique<DropShadow>(this);
+  m_shadow = new DropShadow(this);
   setObjectName("LoginWindow");
   setStyleSheet(R"(
     #LoginWindow {

--- a/Applications/Spire/Source/OrderImbalanceIndicator/OrderImbalanceIndicatorContextMenu.cpp
+++ b/Applications/Spire/Source/OrderImbalanceIndicator/OrderImbalanceIndicatorContextMenu.cpp
@@ -26,7 +26,7 @@ OrderImbalanceIndicatorContextMenu::OrderImbalanceIndicatorContextMenu(
     QWidget* parent)
     : QMenu(parent) {
   setWindowFlag(Qt::NoDropShadowWindowHint);
-  m_drop_shadow = std::make_unique<DropShadow>(true, true, this);
+  m_drop_shadow = new DropShadow(true, true, this);
   setFixedSize(CONTEXT_MENU_SIZE());
   setStyleSheet(QString(R"(
     QMenu {
@@ -73,8 +73,7 @@ OrderImbalanceIndicatorContextMenu::OrderImbalanceIndicatorContextMenu(
     .arg(scale_height(6)).arg(scale_width(4)));
   m_table_columns_menu = new QMenu(tr("Table Columns"), this);
   m_table_columns_menu->setWindowFlag(Qt::NoDropShadowWindowHint);
-  m_sub_menu_drop_shadow = std::make_unique<DropShadow>(false, true,
-    m_table_columns_menu);
+  m_sub_menu_drop_shadow = new DropShadow(false, true, m_table_columns_menu);
   m_table_columns_menu->installEventFilter(this);
   m_table_columns_menu->setFixedSize(SUB_MENU_SIZE());
   m_table_columns_menu->setContentsMargins(0, scale_height(0), 0,

--- a/Applications/Spire/Source/SecurityInput/SecurityInfoListView.cpp
+++ b/Applications/Spire/Source/SecurityInput/SecurityInfoListView.cpp
@@ -22,7 +22,7 @@ SecurityInfoListView::SecurityInfoListView(QWidget* parent)
   setAttribute(Qt::WA_ShowWithoutActivating);
   setAttribute(Qt::WA_TranslucentBackground);
   setStyleSheet("border-color: transparent;");
-  m_shadow = std::make_unique<DropShadow>(false, this);
+  m_shadow = new DropShadow(false, this);
   auto layout = new QVBoxLayout(this);
   layout->setContentsMargins({});
   layout->setSpacing(0);

--- a/Applications/Spire/Source/SecurityInput/SecurityInputDialog.cpp
+++ b/Applications/Spire/Source/SecurityInput/SecurityInputDialog.cpp
@@ -25,7 +25,7 @@ SecurityInputDialog::SecurityInputDialog(Ref<SecurityInputModel> model,
       m_initial_text(initial_text),
       m_is_dragging(false) {
   setWindowModality(Qt::WindowModal);
-  m_shadow = std::make_unique<DropShadow>(this);
+  m_shadow = new DropShadow(this);
   m_layout = new QVBoxLayout(this);
   m_layout->setContentsMargins(scale_width(8), scale_height(6), scale_width(8),
     scale_height(8));

--- a/Applications/Spire/Source/Toolbar/ToolbarMenu.cpp
+++ b/Applications/Spire/Source/Toolbar/ToolbarMenu.cpp
@@ -15,7 +15,7 @@ ToolbarMenu::ToolbarMenu(const QString& title, QWidget* parent)
       m_empty_style(true) {
   setMenu(m_items);
   m_items->setWindowFlag(Qt::NoDropShadowWindowHint);
-  m_drop_shadow = std::make_unique<DropShadow>(true, true, m_items);
+  m_drop_shadow = new DropShadow(true, true, m_items);
   m_items->setStyle(m_menu_icon_style.get());
   connect(m_items, &QMenu::triggered, this, &ToolbarMenu::on_triggered);
   m_empty_item = new QWidgetAction(this);

--- a/Applications/Spire/Source/Ui/DateInputWidget.cpp
+++ b/Applications/Spire/Source/Ui/DateInputWidget.cpp
@@ -20,7 +20,7 @@ DateInputWidget::DateInputWidget(const ptime& initial_date, QWidget* parent)
     m_calendar_widget->hide();
     update_label(date);
   });
-  m_drop_shadow = std::make_unique<DropShadow>(true, false, m_calendar_widget);
+  m_drop_shadow = new DropShadow(true, false, m_calendar_widget);
   m_calendar_widget->hide();
   update_label(initial_date.date());
   window()->installEventFilter(this);

--- a/Applications/Spire/Source/Ui/DropDownMenuList.cpp
+++ b/Applications/Spire/Source/Ui/DropDownMenuList.cpp
@@ -14,7 +14,7 @@ DropDownMenuList::DropDownMenuList(
       m_highlight_index(-1) {
   setAttribute(Qt::WA_ShowWithoutActivating);
   setAttribute(Qt::WA_TranslucentBackground);
-  m_shadow = std::make_unique<DropShadow>(true, false, this);
+  m_shadow = new DropShadow(true, false, this);
   setFixedHeight(1 + scale_height(20) * items.size());
   auto layout = new QVBoxLayout(this);
   layout->setContentsMargins({});

--- a/Applications/Spire/Source/Ui/DropShadow.cpp
+++ b/Applications/Spire/Source/Ui/DropShadow.cpp
@@ -43,6 +43,9 @@ DropShadow::DropShadow(bool is_menu_shadow, bool has_top, QWidget* parent)
   setAttribute(Qt::WA_TranslucentBackground);
   setAttribute(Qt::WA_ShowWithoutActivating);
   m_parent->window()->installEventFilter(this);
+  connect(m_parent,
+    static_cast<void (QObject::*)(QObject*)>(&QObject::destroyed),
+    [=] (auto object) { deleteLater(); });
   qApp->installNativeEventFilter(this);
 }
 

--- a/Applications/Spire/Source/Ui/DropShadow.cpp
+++ b/Applications/Spire/Source/Ui/DropShadow.cpp
@@ -43,8 +43,7 @@ DropShadow::DropShadow(bool is_menu_shadow, bool has_top, QWidget* parent)
   setAttribute(Qt::WA_TranslucentBackground);
   setAttribute(Qt::WA_ShowWithoutActivating);
   m_parent->window()->installEventFilter(this);
-  connect(m_parent,
-    static_cast<void (QObject::*)(QObject*)>(&QObject::destroyed),
+  connect(m_parent, qOverload<QObject*>(&QObject::destroyed),
     [=] (auto object) { deleteLater(); });
   qApp->installNativeEventFilter(this);
 }


### PR DESCRIPTION
I put a build in the drafts/demos folder in case it's needed.

I tested the callback using the context menu; when the context menu is hidden/destroyed there's two calls to deleteLater(), one for each menu's drop shadow.