### PR TITLE
Scroll area usage

### DIFF
--- a/Applications/Spire/Include/Spire/BookView/BookQuoteTableView.hpp
+++ b/Applications/Spire/Include/Spire/BookView/BookQuoteTableView.hpp
@@ -14,7 +14,7 @@ namespace Spire {
         \param model The model to get the table data from.
         \param parent The parent to this widget.
       */
-      explicit BookQuoteTableView(std::unique_ptr<BookQuoteTableModel> model,
+      explicit BookQuoteTableView(BookQuoteTableModel* model,
         QWidget* parent = nullptr);
 
       //! Sets the properties of the table.
@@ -28,7 +28,7 @@ namespace Spire {
       QStyleOptionViewItem viewOptions() const override;
 
     private:
-      std::unique_ptr<BookQuoteTableModel> m_model;
+      BookQuoteTableModel* m_model;
   };
 }
 

--- a/Applications/Spire/Include/Spire/BookView/BookViewController.hpp
+++ b/Applications/Spire/Include/Spire/BookView/BookViewController.hpp
@@ -44,7 +44,7 @@ namespace Spire {
       Definitions m_definitions;
       SecurityInputModel* m_security_input_model;
       Nexus::VirtualServiceClients* m_service_clients;
-      std::unique_ptr<BookViewWindow> m_window;
+      BookViewWindow* m_window;
       boost::signals2::scoped_connection m_security_change_connection;
 
       void on_change_security(const Nexus::Security& security);

--- a/Applications/Spire/Include/Spire/BookView/BookViewWindow.hpp
+++ b/Applications/Spire/Include/Spire/BookView/BookViewWindow.hpp
@@ -62,7 +62,7 @@ namespace Spire {
       QVBoxLayout* m_layout;
       TechnicalsPanel* m_technicals_panel;
       std::unique_ptr<BboQuotePanel> m_bbo_quote_panel;
-      std::unique_ptr<TransitionWidget> m_transition_widget;
+      TransitionWidget* m_transition_widget;
       QWidget* m_quote_widgets_container;
       QVBoxLayout* m_quote_widgets_container_layout;
       std::unique_ptr<BookViewTableWidget> m_table;

--- a/Applications/Spire/Include/Spire/BookView/BookViewWindow.hpp
+++ b/Applications/Spire/Include/Spire/BookView/BookViewWindow.hpp
@@ -61,11 +61,11 @@ namespace Spire {
       SecurityWidget* m_security_widget;
       QVBoxLayout* m_layout;
       TechnicalsPanel* m_technicals_panel;
-      std::unique_ptr<BboQuotePanel> m_bbo_quote_panel;
+      BboQuotePanel* m_bbo_quote_panel;
       TransitionWidget* m_transition_widget;
       QWidget* m_quote_widgets_container;
       QVBoxLayout* m_quote_widgets_container_layout;
-      std::unique_ptr<BookViewTableWidget> m_table;
+      BookViewTableWidget* m_table;
       QtPromise<void> m_data_loaded_promise;
       bool m_is_data_loaded;
       boost::signals2::scoped_connection m_dialog_apply_connection;

--- a/Applications/Spire/Include/Spire/Login/LoginController.hpp
+++ b/Applications/Spire/Include/Spire/Login/LoginController.hpp
@@ -70,7 +70,7 @@ namespace Spire {
       mutable LoggedInSignal m_logged_in_signal;
       std::vector<ServerEntry> m_servers;
       ServiceClientsFactory m_service_clients_factory;
-      std::unique_ptr<LoginWindow> m_login_window;
+      LoginWindow* m_login_window;
       QtPromise<std::unique_ptr<Nexus::VirtualServiceClients>> m_login_promise;
       std::unique_ptr<Nexus::VirtualServiceClients> m_service_clients;
 

--- a/Applications/Spire/Include/Spire/SecurityInput/SecurityInfoListView.hpp
+++ b/Applications/Spire/Include/Spire/SecurityInput/SecurityInfoListView.hpp
@@ -1,7 +1,6 @@
 #ifndef SPIRE_SECURITY_INFO_LIST_VIEW_HPP
 #define SPIRE_SECURITY_INFO_LIST_VIEW_HPP
 #include <vector>
-#include <QScrollArea>
 #include "Nexus/Definitions/SecurityInfo.hpp"
 #include "Spire/SecurityInput/SecurityInput.hpp"
 #include "Spire/Ui/Ui.hpp"
@@ -51,7 +50,7 @@ namespace Spire {
       mutable ActivateSignal m_activate_signal;
       mutable CommitSignal m_commit_signal;
       DropShadow* m_shadow;
-      QScrollArea* m_scroll_area;
+      ScrollArea* m_scroll_area;
       QWidget* m_list_widget;
       QWidget* m_key_widget;
       int m_highlighted_index;

--- a/Applications/Spire/Include/Spire/Spire/Utility.hpp
+++ b/Applications/Spire/Include/Spire/Spire/Utility.hpp
@@ -1,7 +1,20 @@
 #ifndef SPIRE_UTILITY_HPP
 #define SPIRE_UTILITY_HPP
+#include <QObject>
 
 namespace Spire {
+
+  //! Deletes an object when control returns to the thread's event loop.
+  /*
+    \param object The object to schedule for deletion.
+  */
+  template<typename T>
+  std::enable_if_t<std::is_base_of_v<QObject, T>> deleteLater(T*& object) {
+    if(object != nullptr) {
+      object->deleteLater();
+      object = nullptr;
+    }
+  }
 
   //! Returns the minimum of the given parameters. Returns the first given
   //! parameter if they are equal.

--- a/Applications/Spire/Include/Spire/Spire/Utility.hpp
+++ b/Applications/Spire/Include/Spire/Spire/Utility.hpp
@@ -9,7 +9,7 @@ namespace Spire {
     \param object The object to schedule for deletion.
   */
   template<typename T>
-  std::enable_if_t<std::is_base_of_v<QObject, T>> deleteLater(T*& object) {
+  std::enable_if_t<std::is_base_of_v<QObject, T>> delete_later(T*& object) {
     if(object != nullptr) {
       object->deleteLater();
       object = nullptr;

--- a/Applications/Spire/Include/Spire/TimeAndSales/TimeAndSalesController.hpp
+++ b/Applications/Spire/Include/Spire/TimeAndSales/TimeAndSalesController.hpp
@@ -44,7 +44,7 @@ namespace Spire {
       Definitions m_definitions;
       SecurityInputModel* m_security_input_model;
       Nexus::VirtualServiceClients* m_service_clients;
-      std::unique_ptr<TimeAndSalesWindow> m_window;
+      TimeAndSalesWindow* m_window;
 
       void on_change_security(const Nexus::Security& security);
       void on_closed();

--- a/Applications/Spire/Include/Spire/TimeAndSales/TimeAndSalesTableView.hpp
+++ b/Applications/Spire/Include/Spire/TimeAndSales/TimeAndSalesTableView.hpp
@@ -2,16 +2,16 @@
 #define SPIRE_TIME_AND_SALES_TABLE_VIEW_HPP
 #include <QAbstractItemModel>
 #include <QHeaderView>
-#include <QScrollArea>
 #include <QTimer>
 #include <QVBoxLayout>
 #include "Spire/TimeAndSales/TimeAndSalesProperties.hpp"
+#include "Spire/Ui/ScrollArea.hpp"
 #include "Spire/Ui/Ui.hpp"
 
 namespace Spire {
 
   //! Displays a table with horizontal header and loading widget.
-  class TimeAndSalesTableView : public QScrollArea {
+  class TimeAndSalesTableView : public ScrollArea {
     public:
 
       //! Constructs a TimeAndSalesTableView.
@@ -33,10 +33,8 @@ namespace Spire {
       void set_properties(const TimeAndSalesProperties& properties);
 
     protected:
-      bool event(QEvent* event) override;
       bool eventFilter(QObject* watched, QEvent* event) override;
       void resizeEvent(QResizeEvent* event) override;
-      void wheelEvent(QWheelEvent* event) override;
 
     private:
       QVBoxLayout* m_layout;
@@ -46,18 +44,11 @@ namespace Spire {
       TimeAndSalesWindowModel* m_model;
       boost::signals2::scoped_connection m_model_begin_loading_connection;
       boost::signals2::scoped_connection m_model_end_loading_connection;
-      QTimer m_h_scroll_bar_timer;
-      QTimer m_v_scroll_bar_timer;
       std::unique_ptr<SnapshotLoadingWidget> m_loading_widget;
       std::unique_ptr<TransitionWidget> m_transition_widget;
 
-      void fade_out_horizontal_scroll_bar();
-      void fade_out_vertical_scroll_bar();
-      void set_scroll_bar_style(int size);
       void show_loading_widget();
       void update_table_height(int num_rows);
-      bool is_within_horizontal_scroll_bar(const QPoint& pos);
-      bool is_within_vertical_scroll_bar(const QPoint& pos);
       void on_end_loading_signal();
       void on_header_resize(int index, int old_size, int new_size);
       void on_header_move(int logical_index, int old_index, int new_index);

--- a/Applications/Spire/Include/Spire/TimeAndSales/TimeAndSalesTableView.hpp
+++ b/Applications/Spire/Include/Spire/TimeAndSales/TimeAndSalesTableView.hpp
@@ -44,8 +44,8 @@ namespace Spire {
       TimeAndSalesWindowModel* m_model;
       boost::signals2::scoped_connection m_model_begin_loading_connection;
       boost::signals2::scoped_connection m_model_end_loading_connection;
-      std::unique_ptr<SnapshotLoadingWidget> m_loading_widget;
-      std::unique_ptr<TransitionWidget> m_transition_widget;
+      SnapshotLoadingWidget* m_loading_widget;
+      TransitionWidget* m_transition_widget;
 
       void show_loading_widget();
       void update_table_height(int num_rows);

--- a/Applications/Spire/Include/Spire/Toolbar/ToolbarController.hpp
+++ b/Applications/Spire/Include/Spire/Toolbar/ToolbarController.hpp
@@ -46,7 +46,7 @@ namespace Spire {
       Nexus::VirtualServiceClients* m_service_clients;
       RecentlyClosedModel m_model;
       std::unique_ptr<SecurityInputModel> m_security_input_model;
-      std::unique_ptr<ToolbarWindow> m_toolbar_window;
+      ToolbarWindow* m_toolbar_window;
       std::vector<std::unique_ptr<BaseController>> m_controllers;
 
       void on_open_window(RecentlyClosedModel::Type window);

--- a/Applications/Spire/Include/Spire/Ui/DropDownMenuList.hpp
+++ b/Applications/Spire/Include/Spire/Ui/DropDownMenuList.hpp
@@ -1,6 +1,5 @@
 #ifndef SPIRE_DROP_DOWN_MENU_LIST_HPP
 #define SPIRE_DROP_DOWN_MENU_LIST_HPP
-#include <QScrollArea>
 #include <QWidget>
 #include "Spire/Ui/Ui.hpp"
 
@@ -50,7 +49,7 @@ namespace Spire {
     private:
       mutable SelectedSignal m_selected_signal;
       DropShadow* m_shadow;
-      QScrollArea* m_scroll_area;
+      ScrollArea* m_scroll_area;
       QWidget* m_list_widget;
       int m_highlight_index;
 

--- a/Applications/Spire/Include/Spire/Ui/DropShadow.hpp
+++ b/Applications/Spire/Include/Spire/Ui/DropShadow.hpp
@@ -48,7 +48,6 @@ namespace Spire {
 
       void follow_parent();
       QSize shadow_size();
-      void on_parent_destroyed(QObject* parent);
   };
 }
 

--- a/Applications/Spire/Include/Spire/Ui/DropShadow.hpp
+++ b/Applications/Spire/Include/Spire/Ui/DropShadow.hpp
@@ -48,6 +48,7 @@ namespace Spire {
 
       void follow_parent();
       QSize shadow_size();
+      void on_parent_destroyed(QObject* parent);
   };
 }
 

--- a/Applications/Spire/Include/Spire/Ui/ScrollArea.hpp
+++ b/Applications/Spire/Include/Spire/Ui/ScrollArea.hpp
@@ -27,7 +27,7 @@ namespace Spire {
       //! Sets the scroll area's border style.
       /*
         \param width The border width.
-        \param color the Border color.
+        \param color The border color.
       */
       void set_border_style(int width, const QColor& color);
 

--- a/Applications/Spire/Include/Spire/Ui/ScrollArea.hpp
+++ b/Applications/Spire/Include/Spire/Ui/ScrollArea.hpp
@@ -24,6 +24,13 @@ namespace Spire {
       */
       ScrollArea(bool is_dynamic, QWidget* parent = nullptr);
 
+      //! Sets the scroll area's border style.
+      /*
+        \param width The border width.
+        \param color the Border color.
+      */
+      void set_border_style(int width, const QColor& color);
+
       //! Sets the widget displayed in the scroll area.
       /*
         \param widget The widget to display.
@@ -41,6 +48,8 @@ namespace Spire {
       QTimer m_vertical_scroll_bar_timer;
       double m_horizontal_scrolling_error;
       double m_vertical_scrolling_error;
+      QColor m_border_color;
+      int m_border_width;
 
       void hide_horizontal_scroll_bar();
       void hide_vertical_scroll_bar();

--- a/Applications/Spire/Include/Spire/Ui/ScrollArea.hpp
+++ b/Applications/Spire/Include/Spire/Ui/ScrollArea.hpp
@@ -22,7 +22,7 @@ namespace Spire {
                           bars.
         \param parent The parent widget.
       */
-      ScrollArea(bool is_dynamic, QWidget* parent = nullptr);
+      explicit ScrollArea(bool is_dynamic, QWidget* parent = nullptr);
 
       //! Sets the scroll area's border style.
       /*

--- a/Applications/Spire/Include/Spire/Ui/ScrollArea.hpp
+++ b/Applications/Spire/Include/Spire/Ui/ScrollArea.hpp
@@ -9,11 +9,20 @@ namespace Spire {
   class ScrollArea : public QScrollArea {
     public:
 
-      //! Constructs an empty ScrollArea.
+      //! Constructs an empty ScrollArea with static scroll bars.
       /*
         \param parent The parent widget.
       */
       explicit ScrollArea(QWidget* parent = nullptr);
+      
+      //! Constructs an empty ScrollArea.
+      /*
+        \param is_dynamic True if the scroll area should support dynamic-sized,
+                          auto-hiding scroll bars. False for static scroll
+                          bars.
+        \param parent The parent widget.
+      */
+      ScrollArea(bool is_dynamic, QWidget* parent = nullptr);
 
       //! Sets the widget displayed in the scroll area.
       /*
@@ -27,6 +36,7 @@ namespace Spire {
       void wheelEvent(QWheelEvent* event) override;
 
     private:
+      bool m_is_dynamic;
       QTimer m_horizontal_scroll_bar_timer;
       QTimer m_vertical_scroll_bar_timer;
       double m_horizontal_scrolling_error;

--- a/Applications/Spire/Include/Spire/Ui/SecurityWidget.hpp
+++ b/Applications/Spire/Include/Spire/Ui/SecurityWidget.hpp
@@ -66,8 +66,8 @@ namespace Spire {
       Nexus::Security m_current_security;
       QWidget* m_widget;
       QVBoxLayout* m_layout;
-      std::unique_ptr<QLabel> m_empty_window_label;
-      std::unique_ptr<QLabel> m_overlay_widget;
+      QLabel* m_empty_window_label;
+      QLabel* m_overlay_widget;
 
       void on_security_input_accept(SecurityInputDialog* dialog);
       void on_security_input_reject(SecurityInputDialog* dialog);

--- a/Applications/Spire/Source/BookView/BookQuoteTableView.cpp
+++ b/Applications/Spire/Source/BookView/BookQuoteTableView.cpp
@@ -10,7 +10,7 @@ using namespace Spire;
 BookQuoteTableView::BookQuoteTableView(
     BookQuoteTableModel* model, QWidget* parent)
     : QTableView(parent),
-      m_model(std::move(model)) {
+      m_model(model) {
   m_model->setParent(this);
   setStyleSheet(QString(R"(
     border: none;

--- a/Applications/Spire/Source/BookView/BookQuoteTableView.cpp
+++ b/Applications/Spire/Source/BookView/BookQuoteTableView.cpp
@@ -8,9 +8,10 @@
 using namespace Spire;
 
 BookQuoteTableView::BookQuoteTableView(
-    std::unique_ptr<BookQuoteTableModel> model, QWidget* parent)
+    BookQuoteTableModel* model, QWidget* parent)
     : QTableView(parent),
       m_model(std::move(model)) {
+  m_model->setParent(this);
   setStyleSheet(QString(R"(
     border: none;
     gridline-color: #C8C8C8;)"));
@@ -24,7 +25,7 @@ BookQuoteTableView::BookQuoteTableView(
   setFocusPolicy(Qt::NoFocus);
   setItemDelegate(new BookViewTableDelegate(new CustomVariantItemDelegate(),
     this));
-  setModel(m_model.get());
+  setModel(m_model);
 }
 
 void BookQuoteTableView::set_properties(const BookViewProperties& properties) {

--- a/Applications/Spire/Source/BookView/BookViewController.cpp
+++ b/Applications/Spire/Source/BookView/BookViewController.cpp
@@ -38,7 +38,7 @@ void BookViewController::close() {
   if(m_window == nullptr) {
     return;
   }
-  deleteLater(m_window);
+  delete_later(m_window);
   m_closed_signal();
 }
 

--- a/Applications/Spire/Source/BookView/BookViewController.cpp
+++ b/Applications/Spire/Source/BookView/BookViewController.cpp
@@ -1,6 +1,7 @@
 #include "Spire/BookView/BookViewController.hpp"
 #include "Spire/BookView/ServicesBookViewModel.hpp"
 #include "Spire/BookView/BookViewWindow.hpp"
+#include "Spire/Spire/Utility.hpp"
 
 using namespace Beam;
 using namespace boost;
@@ -37,8 +38,7 @@ void BookViewController::close() {
   if(m_window == nullptr) {
     return;
   }
-  m_window->deleteLater();
-  m_window = nullptr;
+  deleteLater(m_window);
   m_closed_signal();
 }
 

--- a/Applications/Spire/Source/BookView/BookViewController.cpp
+++ b/Applications/Spire/Source/BookView/BookViewController.cpp
@@ -13,7 +13,8 @@ BookViewController::BookViewController(Definitions definitions,
     Ref<VirtualServiceClients> service_clients)
     : m_definitions(std::move(definitions)),
       m_security_input_model(security_input_model.Get()),
-      m_service_clients(service_clients.Get()) {}
+      m_service_clients(service_clients.Get()),
+      m_window(nullptr) {}
 
 BookViewController::~BookViewController() {
   close();
@@ -23,7 +24,7 @@ void BookViewController::open() {
   if(m_window != nullptr) {
     return;
   }
-  m_window = std::make_unique<BookViewWindow>(BookViewProperties(),
+  m_window = new BookViewWindow(BookViewProperties(),
     Ref(*m_security_input_model));
   m_security_change_connection = m_window->connect_security_change_signal(
     [=] (const auto& security) { on_change_security(security); });
@@ -36,7 +37,8 @@ void BookViewController::close() {
   if(m_window == nullptr) {
     return;
   }
-  m_window.reset();
+  m_window->deleteLater();
+  m_window = nullptr;
   m_closed_signal();
 }
 

--- a/Applications/Spire/Source/BookView/BookViewHighlightPropertiesWidget.cpp
+++ b/Applications/Spire/Source/BookView/BookViewHighlightPropertiesWidget.cpp
@@ -4,16 +4,15 @@
 #include <QHBoxLayout>
 #include <QLabel>
 #include <QListWidget>
-#include <QScrollArea>
-#include <QScrollBar>
 #include <QShowEvent>
 #include <QVBoxLayout>
 #include "Nexus/Definitions/DefaultMarketDatabase.hpp"
 #include "Spire/BookView/BookViewProperties.hpp"
 #include "Spire/BookView/MarketListItem.hpp"
 #include "Spire/Spire/Dimensions.hpp"
-#include "Spire/Ui/FlatButton.hpp"
 #include "Spire/Ui/CheckBox.hpp"
+#include "Spire/Ui/FlatButton.hpp"
+#include "Spire/Ui/ScrollArea.hpp"
 
 using namespace Nexus;
 using namespace Spire;
@@ -35,45 +34,10 @@ BookViewHighlightPropertiesWidget::BookViewHighlightPropertiesWidget(
   markets_label->setStyleSheet(generic_header_label_stylesheet);
   markets_layout->addWidget(markets_label, 14);
   markets_layout->addStretch(10);
-  auto markets_scroll_area = new QScrollArea(this);
+  auto markets_scroll_area = new ScrollArea(this);
   markets_scroll_area->setFixedWidth(scale_width(140));
   markets_scroll_area->setObjectName("markets_scroll_area");
-  markets_scroll_area->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOn);
-  markets_scroll_area->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
-  markets_scroll_area->verticalScrollBar()->setContextMenuPolicy(
-    Qt::NoContextMenu);
   markets_scroll_area->setWidgetResizable(true);
-  markets_scroll_area->setFrameShape(QFrame::NoFrame);
-  markets_scroll_area->setStyleSheet(QString(R"(
-    #markets_scroll_area {
-      background-color: #FFFFFF;
-      border: %2px solid #A0A0A0;
-    }
-    
-    QScrollBar {
-      background-color: #FFFFFF;
-      border: %2px solid #FFFFFF;
-      width: %1px;
-    }
-
-    QScrollBar::handle:vertical {
-      background-color: #EBEBEB;
-      min-height: %3px;
-    }
-
-    QScrollBar::sub-line:vertical {
-      background: none;
-      border: none;
-      height: 0px;
-      width: 0px;
-    }
-
-    QScrollBar::add-line:vertical {
-      background: none;
-      border: none;
-      height: 0px;
-      width: 0px;
-    })").arg(scale_width(13)).arg(scale_width(1)).arg(scale_height(60)));
   markets_layout->addWidget(markets_scroll_area, 222);
   m_markets_list_widget = new QListWidget(this);
   markets_scroll_area->setWidget(m_markets_list_widget);

--- a/Applications/Spire/Source/BookView/BookViewHighlightPropertiesWidget.cpp
+++ b/Applications/Spire/Source/BookView/BookViewHighlightPropertiesWidget.cpp
@@ -30,12 +30,14 @@ BookViewHighlightPropertiesWidget::BookViewHighlightPropertiesWidget(
   auto generic_header_label_stylesheet = QString(R"(
     color: #4B23A0;
     font-family: Roboto;
-    font-size: %1px;)").arg(scale_height(12));
+    font-size: %1px;
+    font-weight: 550;)").arg(scale_height(12));
   markets_label->setStyleSheet(generic_header_label_stylesheet);
   markets_layout->addWidget(markets_label, 14);
   markets_layout->addStretch(10);
   auto markets_scroll_area = new ScrollArea(this);
   markets_scroll_area->setFixedWidth(scale_width(140));
+  markets_scroll_area->set_border_style(scale_width(1), QColor("#C8C8C8"));
   markets_scroll_area->setObjectName("markets_scroll_area");
   markets_scroll_area->setWidgetResizable(true);
   markets_layout->addWidget(markets_scroll_area, 222);

--- a/Applications/Spire/Source/BookView/BookViewLevelPropertiesWidget.cpp
+++ b/Applications/Spire/Source/BookView/BookViewLevelPropertiesWidget.cpp
@@ -26,13 +26,16 @@ BookViewLevelPropertiesWidget::BookViewLevelPropertiesWidget(
   band_appearance_label->setStyleSheet(QString(R"(
     color: #4B23A0;
     font-family: Roboto;
-    font-size: %1px;)").arg(scale_height(12)));
+    font-size: %1px;
+    font-weight: 550;)").arg(scale_height(12)));
   layout->addWidget(band_appearance_label);
   layout->addStretch(10);
   auto horizontal_layout = new QHBoxLayout();
   horizontal_layout->setContentsMargins({});
   horizontal_layout->setSpacing(0);
   auto band_list_scroll_area = new ScrollArea(this);
+  band_list_scroll_area->setFixedSize(scale(140, 222));
+  band_list_scroll_area->set_border_style(scale_width(1), QColor("#C8C8C8"));
   band_list_scroll_area->setWidgetResizable(true);
   horizontal_layout->addWidget(band_list_scroll_area, 222);
   m_band_list_widget = new QListWidget(this);

--- a/Applications/Spire/Source/BookView/BookViewLevelPropertiesWidget.cpp
+++ b/Applications/Spire/Source/BookView/BookViewLevelPropertiesWidget.cpp
@@ -4,14 +4,13 @@
 #include <QHBoxLayout>
 #include <QLabel>
 #include <QListWidgetItem>
-#include <QScrollArea>
-#include <QScrollBar>
 #include <QSpinBox>
 #include <QVBoxLayout>
 #include "Spire/BookView/BookViewProperties.hpp"
 #include "Spire/Spire/Dimensions.hpp"
 #include "Spire/Ui/CheckBox.hpp"
 #include "Spire/Ui/FlatButton.hpp"
+#include "Spire/Ui/ScrollArea.hpp"
 
 using namespace Spire;
 
@@ -33,44 +32,8 @@ BookViewLevelPropertiesWidget::BookViewLevelPropertiesWidget(
   auto horizontal_layout = new QHBoxLayout();
   horizontal_layout->setContentsMargins({});
   horizontal_layout->setSpacing(0);
-  auto band_list_scroll_area = new QScrollArea(this);
-  band_list_scroll_area->setFixedSize(scale(140, 222));
-  band_list_scroll_area->setObjectName("band_list_scroll_area");
-  band_list_scroll_area->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
-  band_list_scroll_area->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
-  band_list_scroll_area->verticalScrollBar()->setContextMenuPolicy(
-    Qt::NoContextMenu);
+  auto band_list_scroll_area = new ScrollArea(this);
   band_list_scroll_area->setWidgetResizable(true);
-  band_list_scroll_area->setFrameShape(QFrame::NoFrame);
-  band_list_scroll_area->setStyleSheet(QString(R"(
-    #band_list_scroll_area {
-      background-color: #FFFFFF;
-      border: %2px solid #A0A0A0;
-    }
-    
-    QScrollBar {
-      background-color: #FFFFFF;
-      width: %1px;
-    }
-
-    QScrollBar::handle:vertical {
-      background-color: #EBEBEB;
-      min-height: %3px;
-    }
-
-    QScrollBar::sub-line:vertical {
-      background: none;
-      border: none;
-      height: 0px;
-      width: 0px;
-    }
-
-    QScrollBar::add-line:vertical {
-      background: none;
-      border: none;
-      height: 0px;
-      width: 0px;
-    })").arg(scale_width(13)).arg(scale_width(1)).arg(scale_height(60)));
   horizontal_layout->addWidget(band_list_scroll_area, 222);
   m_band_list_widget = new QListWidget(this);
   band_list_scroll_area->setWidget(m_band_list_widget);

--- a/Applications/Spire/Source/BookView/BookViewTableWidget.cpp
+++ b/Applications/Spire/Source/BookView/BookViewTableWidget.cpp
@@ -15,12 +15,10 @@ BookViewTableWidget::BookViewTableWidget(const BookViewModel& model,
   m_layout->setContentsMargins({});
   m_layout->setSpacing(scale_width(2));
   m_bid_table_view = new BookQuoteTableView(
-    std::make_unique<BookQuoteTableModel>(model, Side::BID, m_properties),
-    this);
+    new BookQuoteTableModel(model, Side::BID, m_properties), this);
   m_layout->addWidget(m_bid_table_view);
   m_ask_table_view = new BookQuoteTableView(
-    std::make_unique<BookQuoteTableModel>(model, Side::ASK, m_properties),
-    this);
+    new BookQuoteTableModel(model, Side::ASK, m_properties), this);
   m_layout->addWidget(m_ask_table_view);
   set_properties(std::move(properties));
 }

--- a/Applications/Spire/Source/BookView/BookViewWindow.cpp
+++ b/Applications/Spire/Source/BookView/BookViewWindow.cpp
@@ -62,8 +62,8 @@ void BookViewWindow::set_model(std::shared_ptr<BookViewModel> model) {
   } else {
     m_technicals_panel->reset_model();
   }
-  Spire::deleteLater(m_bbo_quote_panel);
-  Spire::deleteLater(m_table);
+  delete_later(m_bbo_quote_panel);
+  delete_later(m_table);
   if(m_transition_widget == nullptr) {
     m_transition_widget = new TransitionWidget(m_quote_widgets_container);
   }
@@ -143,7 +143,7 @@ void BookViewWindow::show_properties_dialog() {
 }
 
 void BookViewWindow::on_data_loaded(Expect<void> value) {
-  Spire::deleteLater(m_transition_widget);
+  delete_later(m_transition_widget);
   m_is_data_loaded = true;
   m_technicals_panel->set_model(m_model);
   m_bbo_quote_panel = new BboQuotePanel(*m_model, this);

--- a/Applications/Spire/Source/BookView/BookViewWindow.cpp
+++ b/Applications/Spire/Source/BookView/BookViewWindow.cpp
@@ -27,7 +27,9 @@ BookViewWindow::BookViewWindow(const BookViewProperties& properties,
       m_input_model(input_model.Get()),
       m_is_data_loaded(false),
       m_technicals_panel(nullptr),
-      m_transition_widget(nullptr) {
+      m_transition_widget(nullptr),
+      m_bbo_quote_panel(nullptr),
+      m_table(nullptr) {
   setMinimumSize(scale(220, 280));
   resize_body(scale(220, 410));
   setWindowTitle(tr("Book View"));
@@ -59,8 +61,14 @@ void BookViewWindow::set_model(std::shared_ptr<BookViewModel> model) {
   } else {
     m_technicals_panel->reset_model();
   }
-  m_bbo_quote_panel.reset();
-  m_table.reset();
+  if(m_bbo_quote_panel != nullptr) {
+    m_bbo_quote_panel->deleteLater();
+    m_bbo_quote_panel = nullptr;
+  }
+  if(m_table != nullptr) {
+    m_table->deleteLater();
+    m_table = nullptr;
+  }
   if(m_transition_widget == nullptr) {
     m_transition_widget = new TransitionWidget(m_quote_widgets_container);
   }
@@ -146,8 +154,8 @@ void BookViewWindow::on_data_loaded(Expect<void> value) {
   }
   m_is_data_loaded = true;
   m_technicals_panel->set_model(m_model);
-  m_bbo_quote_panel = std::make_unique<BboQuotePanel>(*m_model, this);
-  m_quote_widgets_container_layout->addWidget(m_bbo_quote_panel.get());
-  m_table = std::make_unique<BookViewTableWidget>(*m_model, m_properties, this);
-  m_quote_widgets_container_layout->addWidget(m_table.get());
+  m_bbo_quote_panel = new BboQuotePanel(*m_model, this);
+  m_quote_widgets_container_layout->addWidget(m_bbo_quote_panel);
+  m_table = new BookViewTableWidget(*m_model, m_properties, this);
+  m_quote_widgets_container_layout->addWidget(m_table);
 }

--- a/Applications/Spire/Source/BookView/BookViewWindow.cpp
+++ b/Applications/Spire/Source/BookView/BookViewWindow.cpp
@@ -26,7 +26,8 @@ BookViewWindow::BookViewWindow(const BookViewProperties& properties,
     : Window(parent),
       m_input_model(input_model.Get()),
       m_is_data_loaded(false),
-      m_technicals_panel(nullptr) {
+      m_technicals_panel(nullptr),
+      m_transition_widget(nullptr) {
   setMinimumSize(scale(220, 280));
   resize_body(scale(220, 410));
   setWindowTitle(tr("Book View"));
@@ -61,8 +62,7 @@ void BookViewWindow::set_model(std::shared_ptr<BookViewModel> model) {
   m_bbo_quote_panel.reset();
   m_table.reset();
   if(m_transition_widget == nullptr) {
-    m_transition_widget = std::make_unique<TransitionWidget>(
-      m_quote_widgets_container);
+    m_transition_widget = new TransitionWidget(m_quote_widgets_container);
   }
   m_is_data_loaded = false;
   m_model = std::move(model);
@@ -140,7 +140,10 @@ void BookViewWindow::show_properties_dialog() {
 }
 
 void BookViewWindow::on_data_loaded(Expect<void> value) {
-  m_transition_widget.reset();
+  if(m_transition_widget != nullptr) {
+    m_transition_widget->deleteLater();
+    m_transition_widget = nullptr;
+  }
   m_is_data_loaded = true;
   m_technicals_panel->set_model(m_model);
   m_bbo_quote_panel = std::make_unique<BboQuotePanel>(*m_model, this);

--- a/Applications/Spire/Source/BookView/BookViewWindow.cpp
+++ b/Applications/Spire/Source/BookView/BookViewWindow.cpp
@@ -9,6 +9,7 @@
 #include "Spire/BookView/TechnicalsPanel.hpp"
 #include "Spire/SecurityInput/SecurityInputDialog.hpp"
 #include "Spire/Spire/Dimensions.hpp"
+#include "Spire/Spire/Utility.hpp"
 #include "Spire/Ui/CustomQtVariants.hpp"
 #include "Spire/Ui/DropShadow.hpp"
 #include "Spire/Ui/SecurityWidget.hpp"
@@ -61,14 +62,8 @@ void BookViewWindow::set_model(std::shared_ptr<BookViewModel> model) {
   } else {
     m_technicals_panel->reset_model();
   }
-  if(m_bbo_quote_panel != nullptr) {
-    m_bbo_quote_panel->deleteLater();
-    m_bbo_quote_panel = nullptr;
-  }
-  if(m_table != nullptr) {
-    m_table->deleteLater();
-    m_table = nullptr;
-  }
+  Spire::deleteLater(m_bbo_quote_panel);
+  Spire::deleteLater(m_table);
   if(m_transition_widget == nullptr) {
     m_transition_widget = new TransitionWidget(m_quote_widgets_container);
   }
@@ -148,10 +143,7 @@ void BookViewWindow::show_properties_dialog() {
 }
 
 void BookViewWindow::on_data_loaded(Expect<void> value) {
-  if(m_transition_widget != nullptr) {
-    m_transition_widget->deleteLater();
-    m_transition_widget = nullptr;
-  }
+  Spire::deleteLater(m_transition_widget);
   m_is_data_loaded = true;
   m_technicals_panel->set_model(m_model);
   m_bbo_quote_panel = new BboQuotePanel(*m_model, this);

--- a/Applications/Spire/Source/Login/LoginController.cpp
+++ b/Applications/Spire/Source/Login/LoginController.cpp
@@ -3,6 +3,7 @@
 #include "Nexus/ServiceClients/VirtualServiceClients.hpp"
 #include "Spire/Login/LoginWindow.hpp"
 #include "Spire/Spire/QtPromise.hpp"
+#include "Spire/Spire/Utility.hpp"
 #include "Version.hpp"
 
 using namespace Beam;
@@ -60,8 +61,7 @@ void LoginController::on_login_promise(
   try {
     m_service_clients = std::move(service_clients.Get());
     m_login_window->close();
-    m_login_window->deleteLater();
-    m_login_window = nullptr;
+    deleteLater(m_login_window);
     auto definitions = Definitions(
       m_service_clients->GetDefinitionsClient().LoadCountryDatabase(),
       m_service_clients->GetDefinitionsClient().LoadMarketDatabase(),

--- a/Applications/Spire/Source/Login/LoginController.cpp
+++ b/Applications/Spire/Source/Login/LoginController.cpp
@@ -15,7 +15,8 @@ using namespace Spire;
 LoginController::LoginController(std::vector<ServerEntry> servers,
     ServiceClientsFactory service_clients_factory)
     : m_servers(std::move(servers)),
-      m_service_clients_factory(std::move(service_clients_factory)) {}
+      m_service_clients_factory(std::move(service_clients_factory)),
+      m_login_window(nullptr) {}
 
 LoginController::~LoginController() = default;
 
@@ -24,7 +25,7 @@ std::unique_ptr<VirtualServiceClients>& LoginController::get_service_clients() {
 }
 
 void LoginController::open() {
-  m_login_window = std::make_unique<LoginWindow>(SPIRE_VERSION);
+  m_login_window = new LoginWindow(SPIRE_VERSION);
   m_login_window->connect_login_signal(
     [=] (const auto& p1, const auto& p2) { on_login(p1, p2); });
   m_login_window->connect_cancel_signal([=] () { on_cancel(); });
@@ -59,7 +60,8 @@ void LoginController::on_login_promise(
   try {
     m_service_clients = std::move(service_clients.Get());
     m_login_window->close();
-    m_login_window.reset();
+    m_login_window->deleteLater();
+    m_login_window = nullptr;
     auto definitions = Definitions(
       m_service_clients->GetDefinitionsClient().LoadCountryDatabase(),
       m_service_clients->GetDefinitionsClient().LoadMarketDatabase(),

--- a/Applications/Spire/Source/Login/LoginController.cpp
+++ b/Applications/Spire/Source/Login/LoginController.cpp
@@ -61,7 +61,7 @@ void LoginController::on_login_promise(
   try {
     m_service_clients = std::move(service_clients.Get());
     m_login_window->close();
-    deleteLater(m_login_window);
+    delete_later(m_login_window);
     auto definitions = Definitions(
       m_service_clients->GetDefinitionsClient().LoadCountryDatabase(),
       m_service_clients->GetDefinitionsClient().LoadMarketDatabase(),

--- a/Applications/Spire/Source/SecurityInput/SecurityInfoListView.cpp
+++ b/Applications/Spire/Source/SecurityInput/SecurityInfoListView.cpp
@@ -4,6 +4,7 @@
 #include "Spire/Spire/Dimensions.hpp"
 #include "Spire/Spire/Utility.hpp"
 #include "Spire/Ui/DropShadow.hpp"
+#include "Spire/Ui/ScrollArea.hpp"
 
 using namespace boost;
 using namespace boost::signals2;
@@ -26,41 +27,9 @@ SecurityInfoListView::SecurityInfoListView(QWidget* parent)
   auto layout = new QVBoxLayout(this);
   layout->setContentsMargins({});
   layout->setSpacing(0);
-  m_scroll_area = new QScrollArea(this);
+  m_scroll_area = new ScrollArea(this);
   m_scroll_area->setWidgetResizable(true);
   m_scroll_area->setObjectName("security_info_list_view_scroll_area");
-  m_scroll_area->setFrameShape(QFrame::NoFrame);
-  m_scroll_area->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
-  m_scroll_area->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
-  m_scroll_area->setStyleSheet(QString(R"(
-    #security_info_list_view_scroll_area {
-      background-color: #FFFFFF;
-      border-bottom: %2px solid #A0A0A0;
-      border-left: %2px solid #A0A0A0;
-      border-right: %2px solid #A0A0A0;
-      border-top: none;
-    }
-    
-    QScrollBar {
-      background-color: #FFFFFF;
-      border: none;
-    }
-
-    QScrollBar::handle:vertical {
-      background-color: #EBEBEB;
-      margin-left: %3px;
-      width: %1px;
-    }
-
-    QScrollBar::sub-line:vertical {
-      background: none;
-      border: none;
-    }
-
-    QScrollBar::add-line:vertical {
-      background: none;
-      border: none;
-    })").arg(scale_width(13)).arg(scale_width(1)).arg(scale_width(2)));
   layout->addWidget(m_scroll_area);
   m_list_widget = new QWidget(m_scroll_area);
   auto list_layout = new QVBoxLayout(m_list_widget);

--- a/Applications/Spire/Source/TimeAndSales/TimeAndSalesController.cpp
+++ b/Applications/Spire/Source/TimeAndSales/TimeAndSalesController.cpp
@@ -38,7 +38,7 @@ void TimeAndSalesController::close() {
   if(m_window == nullptr) {
     return;
   }
-  deleteLater(m_window);
+  delete_later(m_window);
   m_closed_signal();
 }
 

--- a/Applications/Spire/Source/TimeAndSales/TimeAndSalesController.cpp
+++ b/Applications/Spire/Source/TimeAndSales/TimeAndSalesController.cpp
@@ -1,4 +1,5 @@
 #include "Spire/TimeAndSales/TimeAndSalesController.hpp"
+#include "Spire/Spire/Utility.hpp"
 #include "Spire/TimeAndSales/ServicesTimeAndSalesModel.hpp"
 #include "Spire/TimeAndSales/TimeAndSalesWindow.hpp"
 
@@ -37,8 +38,7 @@ void TimeAndSalesController::close() {
   if(m_window == nullptr) {
     return;
   }
-  m_window->deleteLater();
-  m_window = nullptr;
+  deleteLater(m_window);
   m_closed_signal();
 }
 

--- a/Applications/Spire/Source/TimeAndSales/TimeAndSalesController.cpp
+++ b/Applications/Spire/Source/TimeAndSales/TimeAndSalesController.cpp
@@ -13,7 +13,8 @@ TimeAndSalesController::TimeAndSalesController(Definitions definitions,
     Ref<VirtualServiceClients> service_clients)
     : m_definitions(std::move(definitions)),
       m_security_input_model(security_input_model.Get()),
-      m_service_clients(service_clients.Get()) {}
+      m_service_clients(service_clients.Get()),
+      m_window(nullptr) {}
 
 TimeAndSalesController::~TimeAndSalesController() {
   close();
@@ -23,7 +24,7 @@ void TimeAndSalesController::open() {
   if(m_window != nullptr) {
     return;
   }
-  m_window = std::make_unique<TimeAndSalesWindow>(TimeAndSalesProperties(),
+  m_window = new TimeAndSalesWindow(TimeAndSalesProperties(),
     Ref(*m_security_input_model));
   m_window->connect_change_security_signal(
     [=] (const auto& security) { on_change_security(security); });
@@ -36,7 +37,8 @@ void TimeAndSalesController::close() {
   if(m_window == nullptr) {
     return;
   }
-  m_window.reset();
+  m_window->deleteLater();
+  m_window = nullptr;
   m_closed_signal();
 }
 

--- a/Applications/Spire/Source/TimeAndSales/TimeAndSalesTableView.cpp
+++ b/Applications/Spire/Source/TimeAndSales/TimeAndSalesTableView.cpp
@@ -5,6 +5,7 @@
 #include <QScrollBar>
 #include <QTableView>
 #include "Spire/Spire/Dimensions.hpp"
+#include "Spire/Spire/Utility.hpp"
 #include "Spire/TimeAndSales/SnapshotLoadingWidget.hpp"
 #include "Spire/TimeAndSales/TimeAndSalesWindowModel.hpp"
 #include "Spire/Ui/CustomQtVariants.hpp"
@@ -88,10 +89,7 @@ TimeAndSalesTableView::TimeAndSalesTableView(QWidget* parent)
 
 void TimeAndSalesTableView::set_model(TimeAndSalesWindowModel* model) {
   m_model = model;
-  if(m_loading_widget != nullptr) {
-    m_loading_widget->deleteLater();
-    m_loading_widget = nullptr;
-  }
+  Spire::deleteLater(m_loading_widget);
   if(m_model->is_loading() && m_transition_widget == nullptr) {
     m_transition_widget = new TransitionWidget(this);
   }
@@ -159,14 +157,8 @@ void TimeAndSalesTableView::update_table_height(int num_rows) {
 }
 
 void TimeAndSalesTableView::on_end_loading_signal() {
-  if(m_transition_widget != nullptr) {
-    m_transition_widget->deleteLater();
-    m_transition_widget = nullptr;
-  }
-  if(m_loading_widget != nullptr) {
-    m_loading_widget->deleteLater();
-    m_loading_widget = nullptr;
-  }
+  Spire::deleteLater(m_transition_widget);
+  Spire::deleteLater(m_loading_widget);
 }
 
 void TimeAndSalesTableView::on_header_resize(int index, int old_size,

--- a/Applications/Spire/Source/TimeAndSales/TimeAndSalesTableView.cpp
+++ b/Applications/Spire/Source/TimeAndSales/TimeAndSalesTableView.cpp
@@ -89,7 +89,7 @@ TimeAndSalesTableView::TimeAndSalesTableView(QWidget* parent)
 
 void TimeAndSalesTableView::set_model(TimeAndSalesWindowModel* model) {
   m_model = model;
-  Spire::deleteLater(m_loading_widget);
+  delete_later(m_loading_widget);
   if(m_model->is_loading() && m_transition_widget == nullptr) {
     m_transition_widget = new TransitionWidget(this);
   }
@@ -157,8 +157,8 @@ void TimeAndSalesTableView::update_table_height(int num_rows) {
 }
 
 void TimeAndSalesTableView::on_end_loading_signal() {
-  Spire::deleteLater(m_transition_widget);
-  Spire::deleteLater(m_loading_widget);
+  delete_later(m_transition_widget);
+  delete_later(m_loading_widget);
 }
 
 void TimeAndSalesTableView::on_header_resize(int index, int old_size,

--- a/Applications/Spire/Source/TimeAndSales/TimeAndSalesTableView.cpp
+++ b/Applications/Spire/Source/TimeAndSales/TimeAndSalesTableView.cpp
@@ -21,14 +21,8 @@ namespace {
 }
 
 TimeAndSalesTableView::TimeAndSalesTableView(QWidget* parent)
-    : QScrollArea(parent),
+    : ScrollArea(parent),
       m_model(nullptr) {
-  setMouseTracking(true);
-  setAttribute(Qt::WA_Hover);
-  horizontalScrollBar()->setContextMenuPolicy(Qt::NoContextMenu);
-  verticalScrollBar()->setContextMenuPolicy(Qt::NoContextMenu);
-  setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
-  setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
   connect(horizontalScrollBar(), &QScrollBar::valueChanged, this,
     &TimeAndSalesTableView::on_horizontal_slider_value_changed);
   connect(verticalScrollBar(), &QScrollBar::valueChanged, this,
@@ -87,12 +81,6 @@ TimeAndSalesTableView::TimeAndSalesTableView(QWidget* parent)
   m_table->setItemDelegate(new ItemPaddingDelegate(scale_width(5),
     new CustomVariantItemDelegate(), this));
   m_layout->addWidget(m_table);
-  m_h_scroll_bar_timer.setInterval(SCROLL_BAR_FADE_TIME_MS);
-  connect(&m_h_scroll_bar_timer, &QTimer::timeout, this,
-    &TimeAndSalesTableView::fade_out_horizontal_scroll_bar);
-  m_v_scroll_bar_timer.setInterval(SCROLL_BAR_FADE_TIME_MS);
-  connect(&m_v_scroll_bar_timer, &QTimer::timeout, this,
-    &TimeAndSalesTableView::fade_out_vertical_scroll_bar);
   setWidget(main_widget);
 }
 
@@ -135,43 +123,6 @@ void TimeAndSalesTableView::set_properties(
   }
 }
 
-bool TimeAndSalesTableView::event(QEvent* event) {
-  if(event->type() == QEvent::HoverMove) {
-    auto e = static_cast<QHoverEvent*>(event);
-    if(is_within_horizontal_scroll_bar(e->pos()) &&
-        !verticalScrollBar()->isVisible()) {
-      set_scroll_bar_style(SCROLL_BAR_MAX_SIZE);
-      setHorizontalScrollBarPolicy(Qt::ScrollBarAsNeeded);
-      setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
-    } else if(is_within_vertical_scroll_bar(e->pos()) &&
-        !horizontalScrollBar()->isSliderDown()) {
-      set_scroll_bar_style(SCROLL_BAR_MAX_SIZE);
-      setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
-      setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
-    } else {
-      set_scroll_bar_style(SCROLL_BAR_MIN_SIZE);
-      if(!m_v_scroll_bar_timer.isActive() &&
-          verticalScrollBarPolicy() != Qt::ScrollBarAlwaysOff &&
-          !verticalScrollBar()->isSliderDown()) {
-        fade_out_vertical_scroll_bar();
-      }
-      if(!m_h_scroll_bar_timer.isActive() &&
-          horizontalScrollBarPolicy() != Qt::ScrollBarAlwaysOff &&
-          !horizontalScrollBar()->isSliderDown()) {
-        fade_out_horizontal_scroll_bar();
-      }
-    }
-  } else if(event->type() == QEvent::HoverLeave) {
-    if(!m_h_scroll_bar_timer.isActive()) {
-      fade_out_horizontal_scroll_bar();
-    }
-    if(!m_v_scroll_bar_timer.isActive()) {
-      fade_out_vertical_scroll_bar();
-    }
-  }
-  return QScrollArea::event(event);
-}
-
 bool TimeAndSalesTableView::eventFilter(QObject* watched, QEvent* event) {
   if(watched == m_table) {
     if(event->type() == QEvent::Paint) {
@@ -179,75 +130,12 @@ bool TimeAndSalesTableView::eventFilter(QObject* watched, QEvent* event) {
       m_header->update();
     }
   }
-  return QScrollArea::eventFilter(watched, event);
+  return ScrollArea::eventFilter(watched, event);
 }
 
 void TimeAndSalesTableView::resizeEvent(QResizeEvent* event) {
   widget()->resize(width(), widget()->height());
   m_header->setFixedWidth(widget()->width());
-}
-
-void TimeAndSalesTableView::wheelEvent(QWheelEvent* event) {
-  if(event->modifiers() & Qt::ShiftModifier) {
-    setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
-    setHorizontalScrollBarPolicy(Qt::ScrollBarAsNeeded);
-    horizontalScrollBar()->setValue(horizontalScrollBar()->value() -
-      (event->delta() / 2));
-    m_h_scroll_bar_timer.start();
-  } else if(!event->modifiers().testFlag(Qt::ShiftModifier)) {
-    setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
-    setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
-    verticalScrollBar()->setValue(verticalScrollBar()->value() -
-      (event->delta() / 2));
-    m_v_scroll_bar_timer.start();
-  }
-}
-
-void TimeAndSalesTableView::fade_out_horizontal_scroll_bar() {
-  m_h_scroll_bar_timer.stop();
-  setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
-}
-
-void TimeAndSalesTableView::fade_out_vertical_scroll_bar() {
-  m_v_scroll_bar_timer.stop();
-  setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
-}
-
-void TimeAndSalesTableView::set_scroll_bar_style(int size) {
-  setStyleSheet(QString(R"(
-    QWidget {
-      background-color: #FFFFFF;
-      border: none;
-    }
-
-    QScrollBar::horizontal {
-      height: %1px;
-    }
-
-    QScrollBar::vertical {
-      width: %2px;
-    }
-
-    QScrollBar::handle {
-      background-color: #C8C8C8;
-    }
-
-    QScrollBar::handle:horizontal {
-      min-width: %3px;
-    }
-
-    QScrollBar::handle:vertical {
-      min-height: %4px;
-    }
-
-    QScrollBar::add-line, QScrollBar::sub-line,
-    QScrollBar::add-page, QScrollBar::sub-page {
-      background: none;
-      border: none;
-      height: 0px;
-      width: 0px;
-    })").arg(scale_height(size)).arg(scale_width(size))
-        .arg(scale_width(60)).arg(scale_height(60)));
 }
 
 void TimeAndSalesTableView::show_loading_widget() {
@@ -263,16 +151,6 @@ void TimeAndSalesTableView::update_table_height(int num_rows) {
     height += m_loading_widget->height();
   }
   widget()->setFixedHeight(height);
-}
-
-bool TimeAndSalesTableView::is_within_horizontal_scroll_bar(
-    const QPoint& pos) {
-  return pos.y() > height() - scale_height(SCROLL_BAR_MAX_SIZE);
-}
-
-bool TimeAndSalesTableView::is_within_vertical_scroll_bar(
-    const QPoint& pos) {
-  return pos.x() > width() - scale_width(SCROLL_BAR_MAX_SIZE);
 }
 
 void TimeAndSalesTableView::on_end_loading_signal() {

--- a/Applications/Spire/Source/TimeAndSales/TimeAndSalesTableView.cpp
+++ b/Applications/Spire/Source/TimeAndSales/TimeAndSalesTableView.cpp
@@ -21,7 +21,7 @@ namespace {
 }
 
 TimeAndSalesTableView::TimeAndSalesTableView(QWidget* parent)
-    : ScrollArea(parent),
+    : ScrollArea(true, parent),
       m_model(nullptr) {
   connect(horizontalScrollBar(), &QScrollBar::valueChanged, this,
     &TimeAndSalesTableView::on_horizontal_slider_value_changed);

--- a/Applications/Spire/Source/Toolbar/ToolbarController.cpp
+++ b/Applications/Spire/Source/Toolbar/ToolbarController.cpp
@@ -2,6 +2,7 @@
 #include "Nexus/ServiceClients/VirtualServiceClients.hpp"
 #include "Spire/BookView/BookViewController.hpp"
 #include "Spire/SecurityInput/ServicesSecurityInputModel.hpp"
+#include "Spire/Spire/Utility.hpp"
 #include "Spire/TimeAndSales/TimeAndSalesController.hpp"
 #include "Spire/Toolbar/ToolbarWindow.hpp"
 
@@ -70,8 +71,7 @@ void ToolbarController::close() {
   }
   auto controllers = std::move(m_controllers);
   controllers.clear();
-  m_toolbar_window->deleteLater();
-  m_toolbar_window = nullptr;
+  deleteLater(m_toolbar_window);
   m_closed_signal();
 }
 

--- a/Applications/Spire/Source/Toolbar/ToolbarController.cpp
+++ b/Applications/Spire/Source/Toolbar/ToolbarController.cpp
@@ -71,7 +71,7 @@ void ToolbarController::close() {
   }
   auto controllers = std::move(m_controllers);
   controllers.clear();
-  deleteLater(m_toolbar_window);
+  delete_later(m_toolbar_window);
   m_closed_signal();
 }
 

--- a/Applications/Spire/Source/Toolbar/ToolbarController.cpp
+++ b/Applications/Spire/Source/Toolbar/ToolbarController.cpp
@@ -44,7 +44,8 @@ ToolbarController::ToolbarController(Definitions definitions,
     : m_definitions(std::move(definitions)),
       m_service_clients(service_clients.Get()),
       m_security_input_model(std::make_unique<ServicesSecurityInputModel>(
-        Ref(m_service_clients->GetMarketDataClient()))) {}
+        Ref(m_service_clients->GetMarketDataClient()))),
+      m_toolbar_window(nullptr) {}
 
 ToolbarController::~ToolbarController() {
   close();
@@ -54,7 +55,7 @@ void ToolbarController::open() {
   if(m_toolbar_window != nullptr) {
     return;
   }
-  m_toolbar_window = std::make_unique<ToolbarWindow>(Ref(m_model),
+  m_toolbar_window = new ToolbarWindow(Ref(m_model),
     m_service_clients->GetServiceLocatorClient().GetAccount());
   m_toolbar_window->connect_open_signal(
     [=] (auto window) { on_open_window(window); });
@@ -69,7 +70,8 @@ void ToolbarController::close() {
   }
   auto controllers = std::move(m_controllers);
   controllers.clear();
-  m_toolbar_window.reset();
+  m_toolbar_window->deleteLater();
+  m_toolbar_window = nullptr;
   m_closed_signal();
 }
 

--- a/Applications/Spire/Source/Ui/DropDownMenu.cpp
+++ b/Applications/Spire/Source/Ui/DropDownMenu.cpp
@@ -2,6 +2,7 @@
 #include <QLayout>
 #include <QPainter>
 #include <QPaintEvent>
+#include <QScrollArea>
 #include "Spire/Spire/Dimensions.hpp"
 #include "Spire/Ui/DropdownMenuItem.hpp"
 #include "Spire/Ui/DropdownMenuList.hpp"

--- a/Applications/Spire/Source/Ui/DropDownMenuList.cpp
+++ b/Applications/Spire/Source/Ui/DropDownMenuList.cpp
@@ -4,6 +4,7 @@
 #include "Spire/Spire/Dimensions.hpp"
 #include "Spire/Ui/DropdownMenuItem.hpp"
 #include "Spire/Ui/DropShadow.hpp"
+#include "Spire/Ui/ScrollArea.hpp"
 
 using namespace boost::signals2;
 using namespace Spire;
@@ -18,41 +19,9 @@ DropDownMenuList::DropDownMenuList(
   setFixedHeight(1 + scale_height(20) * items.size());
   auto layout = new QVBoxLayout(this);
   layout->setContentsMargins({});
-  m_scroll_area = new QScrollArea(this);
+  m_scroll_area = new ScrollArea(this);
   m_scroll_area->setWidgetResizable(true);
   m_scroll_area->setObjectName("dropdown_menu_list_scroll_area");
-  m_scroll_area->setFrameShape(QFrame::NoFrame);
-  m_scroll_area->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
-  m_scroll_area->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
-  m_scroll_area->setStyleSheet(QString(R"(
-    #dropdown_menu_list_scroll_area {
-      background-color: #FFFFFF;
-      border-bottom: %2px solid #A0A0A0;
-      border-left: %2px solid #A0A0A0;
-      border-right: %2px solid #A0A0A0;
-      border-top: none;
-    }
-    
-    QScrollBar {
-      background-color: #FFFFFF;
-      border: none;
-    }
-
-    QScrollBar::handle:vertical {
-      background-color: #EBEBEB;
-      margin-left: %3px;
-      width: %1px;
-    }
-
-    QScrollBar::sub-line:vertical {
-      background: none;
-      border: none;
-    }
-
-    QScrollBar::add-line:vertical {
-      background: none;
-      border: none;
-    })").arg(scale_width(15)).arg(scale_width(1)).arg(scale_width(2)));
   layout->addWidget(m_scroll_area);
   m_list_widget = new QWidget(m_scroll_area);
   auto list_layout = new QVBoxLayout(m_list_widget);

--- a/Applications/Spire/Source/Ui/DropShadow.cpp
+++ b/Applications/Spire/Source/Ui/DropShadow.cpp
@@ -44,7 +44,7 @@ DropShadow::DropShadow(bool is_menu_shadow, bool has_top, QWidget* parent)
   setAttribute(Qt::WA_ShowWithoutActivating);
   m_parent->window()->installEventFilter(this);
   connect(m_parent, qOverload<QObject*>(&QObject::destroyed),
-    this, &DropShadow::on_parent_destroyed);
+    [=] (auto object) { deleteLater(); });
   qApp->installNativeEventFilter(this);
 }
 
@@ -158,8 +158,4 @@ QSize DropShadow::shadow_size() {
   } else {
     return scale(14, 14);
   }
-}
-
-void DropShadow::on_parent_destroyed(QObject* parent) {
-  deleteLater();
 }

--- a/Applications/Spire/Source/Ui/DropShadow.cpp
+++ b/Applications/Spire/Source/Ui/DropShadow.cpp
@@ -44,7 +44,7 @@ DropShadow::DropShadow(bool is_menu_shadow, bool has_top, QWidget* parent)
   setAttribute(Qt::WA_ShowWithoutActivating);
   m_parent->window()->installEventFilter(this);
   connect(m_parent, qOverload<QObject*>(&QObject::destroyed),
-    [=] (auto object) { deleteLater(); });
+    this, &DropShadow::on_parent_destroyed);
   qApp->installNativeEventFilter(this);
 }
 
@@ -158,4 +158,8 @@ QSize DropShadow::shadow_size() {
   } else {
     return scale(14, 14);
   }
+}
+
+void DropShadow::on_parent_destroyed(QObject* parent) {
+  deleteLater();
 }

--- a/Applications/Spire/Source/Ui/ScrollArea.cpp
+++ b/Applications/Spire/Source/Ui/ScrollArea.cpp
@@ -22,11 +22,11 @@ ScrollArea::ScrollArea(bool is_dynamic, QWidget* parent)
       m_horizontal_scrolling_error(0.0),
       m_vertical_scrolling_error(0.0) {
   setFrameStyle(QFrame::NoFrame);
+  setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
   horizontalScrollBar()->setContextMenuPolicy(Qt::NoContextMenu);
   verticalScrollBar()->setContextMenuPolicy(Qt::NoContextMenu);
-  setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
-  setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
   if(m_is_dynamic) {
+    setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
     m_horizontal_scroll_bar_timer.setInterval(SCROLL_BAR_HIDE_TIME_MS);
     connect(&m_horizontal_scroll_bar_timer, &QTimer::timeout, this,
       &ScrollArea::hide_horizontal_scroll_bar);
@@ -35,6 +35,7 @@ ScrollArea::ScrollArea(bool is_dynamic, QWidget* parent)
       &ScrollArea::hide_vertical_scroll_bar);
     set_scroll_bar_style(SCROLL_BAR_MIN_SIZE);
   } else {
+    setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
     set_scroll_bar_style(SCROLL_BAR_MAX_SIZE);
   }
 }

--- a/Applications/Spire/Source/Ui/ScrollArea.cpp
+++ b/Applications/Spire/Source/Ui/ScrollArea.cpp
@@ -20,7 +20,9 @@ ScrollArea::ScrollArea(bool is_dynamic, QWidget* parent)
     : QScrollArea(parent),
       m_is_dynamic(is_dynamic),
       m_horizontal_scrolling_error(0.0),
-      m_vertical_scrolling_error(0.0) {
+      m_vertical_scrolling_error(0.0),
+      m_border_color(Qt::transparent),
+      m_border_width(0) {
   setFrameStyle(QFrame::NoFrame);
   setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
   horizontalScrollBar()->setContextMenuPolicy(Qt::NoContextMenu);
@@ -36,6 +38,16 @@ ScrollArea::ScrollArea(bool is_dynamic, QWidget* parent)
     set_scroll_bar_style(SCROLL_BAR_MIN_SIZE);
   } else {
     setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
+    set_scroll_bar_style(SCROLL_BAR_MAX_SIZE);
+  }
+}
+
+void ScrollArea::set_border_style(int width, const QColor& color) {
+  m_border_color = color;
+  m_border_width = width;
+  if(verticalScrollBar()->width() == SCROLL_BAR_MIN_SIZE) {
+    set_scroll_bar_style(SCROLL_BAR_MIN_SIZE);
+  } else {
     set_scroll_bar_style(SCROLL_BAR_MAX_SIZE);
   }
 }
@@ -152,14 +164,16 @@ void ScrollArea::set_scroll_bar_style(int handle_size) {
   setStyleSheet(QString(R"(
     QWidget {
       background-color: #FFFFFF;
-      border: none;
+      border: %5px solid %6;
     }
 
     QScrollBar::horizontal {
+      border: none;
       height: %1px;
     }
 
     QScrollBar::vertical {
+      border: none;
       width: %2px;
     }
 
@@ -182,5 +196,6 @@ void ScrollArea::set_scroll_bar_style(int handle_size) {
       height: 0px;
       width: 0px;
     })").arg(scale_height(handle_size)).arg(scale_width(handle_size))
-        .arg(scale_width(60)).arg(scale_height(60)));
+        .arg(scale_width(60)).arg(scale_height(60)).arg(m_border_width)
+        .arg(m_border_color.name()));
 }

--- a/Applications/Spire/Source/Ui/ScrollArea.cpp
+++ b/Applications/Spire/Source/Ui/ScrollArea.cpp
@@ -50,40 +50,42 @@ void ScrollArea::setWidget(QWidget* widget) {
 }
 
 bool ScrollArea::eventFilter(QObject* watched, QEvent* event) {
-  if(event->type() == QEvent::HoverMove) {
-    auto e = static_cast<QHoverEvent*>(event);
-    if(is_within_opposite_scroll_bar(verticalScrollBar(), e->pos().y(),
-        widget()->height(), height()) && !verticalScrollBar()->isVisible()) {
-      set_scroll_bar_style(SCROLL_BAR_MAX_SIZE);
-      setHorizontalScrollBarPolicy(Qt::ScrollBarAsNeeded);
-      setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
-    } else if(is_within_opposite_scroll_bar(horizontalScrollBar(),
-        e->pos().x(), widget()->width(), width()) &&
-        !horizontalScrollBar()->isSliderDown()) {
-      set_scroll_bar_style(SCROLL_BAR_MAX_SIZE);
-      setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOn);
-      setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
-    } else {
-      set_scroll_bar_style(SCROLL_BAR_MIN_SIZE);
-      if(!m_vertical_scroll_bar_timer.isActive() &&
-          verticalScrollBarPolicy() != Qt::ScrollBarAlwaysOff &&
-          !verticalScrollBar()->isSliderDown()) {
-        hide_vertical_scroll_bar();
-      }
-      if(!m_horizontal_scroll_bar_timer.isActive() &&
-          horizontalScrollBarPolicy() != Qt::ScrollBarAlwaysOff &&
+  if(m_is_dynamic) {
+    if(event->type() == QEvent::HoverMove) {
+      auto e = static_cast<QHoverEvent*>(event);
+      if(is_within_opposite_scroll_bar(verticalScrollBar(), e->pos().y(),
+          widget()->height(), height()) && !verticalScrollBar()->isVisible()) {
+        set_scroll_bar_style(SCROLL_BAR_MAX_SIZE);
+        setHorizontalScrollBarPolicy(Qt::ScrollBarAsNeeded);
+        setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+      } else if(is_within_opposite_scroll_bar(horizontalScrollBar(),
+          e->pos().x(), widget()->width(), width()) &&
           !horizontalScrollBar()->isSliderDown()) {
+        set_scroll_bar_style(SCROLL_BAR_MAX_SIZE);
+        setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOn);
+        setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+      } else {
+        set_scroll_bar_style(SCROLL_BAR_MIN_SIZE);
+        if(!m_vertical_scroll_bar_timer.isActive() &&
+            verticalScrollBarPolicy() != Qt::ScrollBarAlwaysOff &&
+            !verticalScrollBar()->isSliderDown()) {
+          hide_vertical_scroll_bar();
+        }
+        if(!m_horizontal_scroll_bar_timer.isActive() &&
+            horizontalScrollBarPolicy() != Qt::ScrollBarAlwaysOff &&
+            !horizontalScrollBar()->isSliderDown()) {
+          hide_horizontal_scroll_bar();
+        }
+      }
+    } else if(event->type() == QEvent::HoverLeave) {
+      if(!m_horizontal_scroll_bar_timer.isActive() &&
+          horizontalScrollBarPolicy() == Qt::ScrollBarAlwaysOff) {
         hide_horizontal_scroll_bar();
       }
-    }
-  } else if(event->type() == QEvent::HoverLeave) {
-    if(!m_horizontal_scroll_bar_timer.isActive() &&
-        horizontalScrollBarPolicy() == Qt::ScrollBarAlwaysOff) {
-      hide_horizontal_scroll_bar();
-    }
-    if(!m_vertical_scroll_bar_timer.isActive() &&
-        verticalScrollBarPolicy() == Qt::ScrollBarAlwaysOff) {
-      hide_vertical_scroll_bar();
+      if(!m_vertical_scroll_bar_timer.isActive() &&
+          verticalScrollBarPolicy() == Qt::ScrollBarAlwaysOff) {
+        hide_vertical_scroll_bar();
+      }
     }
   }
   return QScrollArea::eventFilter(watched, event);

--- a/Applications/Spire/Source/Ui/ScrollArea.cpp
+++ b/Applications/Spire/Source/Ui/ScrollArea.cpp
@@ -17,7 +17,7 @@ ScrollArea::ScrollArea(QWidget* parent)
     : QScrollArea(parent),
       m_horizontal_scrolling_error(0.0),
       m_vertical_scrolling_error(0.0) {
-  setMouseTracking(true);
+  setFrameStyle(QFrame::NoFrame);
   horizontalScrollBar()->setContextMenuPolicy(Qt::NoContextMenu);
   verticalScrollBar()->setContextMenuPolicy(Qt::NoContextMenu);
   setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
@@ -28,6 +28,7 @@ ScrollArea::ScrollArea(QWidget* parent)
   m_vertical_scroll_bar_timer.setInterval(SCROLL_BAR_HIDE_TIME_MS);
   connect(&m_vertical_scroll_bar_timer, &QTimer::timeout, this,
     &ScrollArea::hide_vertical_scroll_bar);
+  set_scroll_bar_style(SCROLL_BAR_MIN_SIZE);
 }
 
 void ScrollArea::setWidget(QWidget* widget) {

--- a/Applications/Spire/Source/Ui/SecurityWidget.cpp
+++ b/Applications/Spire/Source/Ui/SecurityWidget.cpp
@@ -2,6 +2,7 @@
 #include <QKeyEvent>
 #include "Spire/SecurityInput/SecurityInputDialog.hpp"
 #include "Spire/Spire/Dimensions.hpp"
+#include "Spire/Spire/Utility.hpp"
 
 using namespace Beam;
 using namespace boost::signals2;
@@ -37,10 +38,7 @@ SecurityWidget::SecurityWidget(Ref<SecurityInputModel> input_model,
 }
 
 void SecurityWidget::set_widget(QWidget* widget) {
-  if(m_empty_window_label != nullptr) {
-    m_empty_window_label->deleteLater();
-    m_empty_window_label = nullptr;
-  }
+  Spire::deleteLater(m_empty_window_label);
   m_widget = widget;
   m_layout->addWidget(m_widget);
   m_widget->show();
@@ -102,19 +100,13 @@ void SecurityWidget::show_overlay_widget() {
 }
 
 void SecurityWidget::hide_overlay_widget() {
-  if(m_overlay_widget != nullptr) {
-    m_overlay_widget->deleteLater();
-    m_overlay_widget = nullptr;
-  }
+  Spire::deleteLater(m_overlay_widget);
 }
 
 void SecurityWidget::on_security_input_accept(SecurityInputDialog* dialog) {
   auto& security = dialog->get_security();
   if(security != Security() && security != m_current_security) {
-    if(m_empty_window_label != nullptr) {
-      m_empty_window_label->deleteLater();
-      m_empty_window_label = nullptr;
-    }
+    Spire::deleteLater(m_empty_window_label);
     m_securities.push(m_current_security);
     m_current_security = security;
     activateWindow();

--- a/Applications/Spire/Source/Ui/SecurityWidget.cpp
+++ b/Applications/Spire/Source/Ui/SecurityWidget.cpp
@@ -69,7 +69,7 @@ void SecurityWidget::keyPressEvent(QKeyEvent* event) {
     event->accept();
   }
   auto pressed_key = event->text();
-  if(pressed_key[0].isLetterOrNumber()) {
+  if(!pressed_key.isEmpty() && pressed_key[0].isLetterOrNumber()) {
     auto dialog = new SecurityInputDialog(Ref(*m_input_model), pressed_key,
       this);
     dialog->setWindowModality(Qt::NonModal);

--- a/Applications/Spire/Source/Ui/SecurityWidget.cpp
+++ b/Applications/Spire/Source/Ui/SecurityWidget.cpp
@@ -38,7 +38,7 @@ SecurityWidget::SecurityWidget(Ref<SecurityInputModel> input_model,
 }
 
 void SecurityWidget::set_widget(QWidget* widget) {
-  Spire::deleteLater(m_empty_window_label);
+  delete_later(m_empty_window_label);
   m_widget = widget;
   m_layout->addWidget(m_widget);
   m_widget->show();
@@ -100,13 +100,13 @@ void SecurityWidget::show_overlay_widget() {
 }
 
 void SecurityWidget::hide_overlay_widget() {
-  Spire::deleteLater(m_overlay_widget);
+  delete_later(m_overlay_widget);
 }
 
 void SecurityWidget::on_security_input_accept(SecurityInputDialog* dialog) {
   auto& security = dialog->get_security();
   if(security != Security() && security != m_current_security) {
-    Spire::deleteLater(m_empty_window_label);
+    delete_later(m_empty_window_label);
     m_securities.push(m_current_security);
     m_current_security = security;
     activateWindow();

--- a/Applications/Spire/Source/Ui/SecurityWidget.cpp
+++ b/Applications/Spire/Source/Ui/SecurityWidget.cpp
@@ -11,7 +11,9 @@ using namespace Spire;
 SecurityWidget::SecurityWidget(Ref<SecurityInputModel> input_model,
     Theme theme, QWidget* parent)
     : QWidget(parent),
-      m_input_model(input_model.Get()) {
+      m_input_model(input_model.Get()),
+      m_empty_window_label(nullptr),
+      m_overlay_widget(nullptr) {
   setFocusPolicy(Qt::ClickFocus);
   auto empty_label_font_color = QColor();
   if(theme == Theme::DARK) {
@@ -23,8 +25,7 @@ SecurityWidget::SecurityWidget(Ref<SecurityInputModel> input_model,
   }
   m_layout = new QVBoxLayout(this);
   m_layout->setContentsMargins({});
-  m_empty_window_label = std::make_unique<QLabel>(
-    tr("Enter a ticker symbol."), this);
+  m_empty_window_label = new QLabel(tr("Enter a ticker symbol."), this);
   m_empty_window_label->setAlignment(Qt::AlignCenter);
   m_empty_window_label->setStyleSheet(QString(R"(
     color: %3;
@@ -32,11 +33,14 @@ SecurityWidget::SecurityWidget(Ref<SecurityInputModel> input_model,
     font-size: %1px;
     padding-top: %2px;)").arg(scale_height(12)).arg(scale_height(16))
     .arg(empty_label_font_color.name()));
-  m_layout->addWidget(m_empty_window_label.get());
+  m_layout->addWidget(m_empty_window_label);
 }
 
 void SecurityWidget::set_widget(QWidget* widget) {
-  m_empty_window_label.reset();
+  if(m_empty_window_label != nullptr) {
+    m_empty_window_label->deleteLater();
+    m_empty_window_label = nullptr;
+  }
   m_widget = widget;
   m_layout->addWidget(m_widget);
   m_widget->show();
@@ -89,7 +93,7 @@ void SecurityWidget::keyPressEvent(QKeyEvent* event) {
 
 void SecurityWidget::show_overlay_widget() {
   auto p = static_cast<QWidget*>(parent());
-  m_overlay_widget = std::make_unique<QLabel>(p);
+  m_overlay_widget = new QLabel(p);
   m_overlay_widget->setStyleSheet(
     "background-color: rgba(245, 245, 245, 153);");
   m_overlay_widget->resize(p->size());
@@ -98,23 +102,29 @@ void SecurityWidget::show_overlay_widget() {
 }
 
 void SecurityWidget::hide_overlay_widget() {
-  m_overlay_widget.reset();
+  if(m_overlay_widget != nullptr) {
+    m_overlay_widget->deleteLater();
+    m_overlay_widget = nullptr;
+  }
 }
 
 void SecurityWidget::on_security_input_accept(SecurityInputDialog* dialog) {
   auto& security = dialog->get_security();
   if(security != Security() && security != m_current_security) {
-    m_empty_window_label.reset();
+    if(m_empty_window_label != nullptr) {
+      m_empty_window_label->deleteLater();
+      m_empty_window_label = nullptr;
+    }
     m_securities.push(m_current_security);
     m_current_security = security;
     activateWindow();
     m_change_security_signal(security);
   }
   dialog->close();
-  m_overlay_widget.reset();
+  hide_overlay_widget();
 }
 
 void SecurityWidget::on_security_input_reject(SecurityInputDialog* dialog) {
   dialog->close();
-  m_overlay_widget.reset();
+  hide_overlay_widget();
 }


### PR DESCRIPTION
I put the builds in the drafts/demos folder. The toolbar window is just there to show its stability after removing the unique_ptr use.

The book view window had the two lists of its properties widgets updated with the new scroll area.

The charting window is to demo that the drop down box is still functioning correctly. There's no functionality so far to limit how many items are displayed, so the scroll bars can't be viewed right now.

The time and sales window was updated to use the dynamic scroll bars.

The security input was updated and can be viewed in one of the tester builds.