### PR TITLE
Key bindings window

### DIFF
--- a/Applications/Spire/Include/Spire/BookView/BookViewPropertiesDialog.hpp
+++ b/Applications/Spire/Include/Spire/BookView/BookViewPropertiesDialog.hpp
@@ -13,15 +13,13 @@ namespace Spire {
     public:
 
       //! Signals that properties should be applied to the parent window.
-      using ApplySignal = Signal<void (const BookViewProperties& properties)>;
+      using ApplySignal = Signal<void ()>;
 
       //! Signals that properties should be applied to all windows.
-      using ApplyAllSignal = Signal<
-        void (const BookViewProperties& properties)>;
+      using ApplyAllSignal = Signal<void ()>;
 
       //! Signals that properties should be saved as the default.
-      using SaveDefaultSignal = Signal<
-        void (const BookViewProperties& properties)>;
+      using SaveDefaultSignal = Signal<void ()>;
 
       //! Constructs a book view properties dialog.
       /*!

--- a/Applications/Spire/Include/Spire/KeyBindings/KeyBindingsWindow.hpp
+++ b/Applications/Spire/Include/Spire/KeyBindings/KeyBindingsWindow.hpp
@@ -5,6 +5,7 @@
 
 namespace Spire {
 
+  //! Displays the user's key bindings.
   class KeyBindingsWindow : public Window {
     public:
 
@@ -14,11 +15,18 @@ namespace Spire {
       */
       using ApplySignal = Signal<void (const KeyBindings& binding)>;
 
-      explicit KeyBindingsWindow(const KeyBindings& key_binding,
+      //! Constructs a key bindings window.
+      /*
+        \param key_bindings The initial key bindings.
+        \param parent The parent widget.
+      */
+      explicit KeyBindingsWindow(const KeyBindings& key_bindings,
         QWidget* parent = nullptr);
 
+      //! Returns the current key bindings.
       const KeyBindings& get_key_bindings() const;
 
+      //! Connects a slot to the applied signal.
       boost::signals2::connection connect_apply_signal(
         const ApplySignal::slot_type& slot) const;
 

--- a/Applications/Spire/Include/Spire/KeyBindings/KeyBindingsWindow.hpp
+++ b/Applications/Spire/Include/Spire/KeyBindings/KeyBindingsWindow.hpp
@@ -1,0 +1,31 @@
+#ifndef SPIRE_KEY_BINDINGS_WINDOW_HPP
+#define SPIRE_KEY_BINDINGS_WINDOW_HPP
+#include "Spire/KeyBindings/KeyBindings.hpp"
+#include "Spire/Ui/Window.hpp"
+
+namespace Spire {
+
+  class KeyBindingsWindow : public Window {
+    public:
+
+      //! Signals that the user applied the current key bindings.
+      /*
+        /param key_bindings The applied key bindings.
+      */
+      using ApplySignal = Signal<void (const KeyBindings& binding)>;
+
+      explicit KeyBindingsWindow(const KeyBindings& key_binding,
+        QWidget* parent = nullptr);
+
+      const KeyBindings& get_key_bindings() const;
+
+      boost::signals2::connection connect_apply_signal(
+        const ApplySignal::slot_type& slot) const;
+
+    private:
+      KeyBindings m_key_bindings;
+      mutable ApplySignal m_apply_signal;
+  };
+}
+
+#endif

--- a/Applications/Spire/Include/Spire/KeyBindings/KeyBindingsWindow.hpp
+++ b/Applications/Spire/Include/Spire/KeyBindings/KeyBindingsWindow.hpp
@@ -10,10 +10,7 @@ namespace Spire {
     public:
 
       //! Signals that the user applied the current key bindings.
-      /*
-        /param key_bindings The applied key bindings.
-      */
-      using ApplySignal = Signal<void (const KeyBindings& binding)>;
+      using ApplySignal = Signal<void ()>;
 
       //! Constructs a key bindings window.
       /*

--- a/Applications/Spire/Include/Spire/TimeAndSales/TimeAndSalesPropertiesDialog.hpp
+++ b/Applications/Spire/Include/Spire/TimeAndSales/TimeAndSalesPropertiesDialog.hpp
@@ -14,16 +14,13 @@ namespace Spire {
     public:
 
       //! Signals that properties should be applied to the parent window.
-      using ApplySignal = Signal<
-        void (const TimeAndSalesProperties& properties)>;
+      using ApplySignal = Signal<void ()>;
 
       //! Signals that properties should be applied to all windows.
-      using ApplyAllSignal = Signal<
-        void (const TimeAndSalesProperties& properties)>;
+      using ApplyAllSignal = Signal<void ()>;
 
       //! Signals that properties should be saved as the default.
-      using SaveDefaultSignal = Signal<
-        void (const TimeAndSalesProperties& properties)>;
+      using SaveDefaultSignal = Signal<void ()>;
 
       //! Constructs a time and sales properties dialog.
       /*!

--- a/Applications/Spire/Source/BookView/BookViewPropertiesDialog.cpp
+++ b/Applications/Spire/Source/BookView/BookViewPropertiesDialog.cpp
@@ -86,13 +86,13 @@ BookViewPropertiesDialog::BookViewPropertiesDialog(
   auto button_group_widget = new PropertiesWindowButtonsWidget(this);
   layout->addWidget(button_group_widget);
   button_group_widget->connect_apply_signal(
-    [=] { m_apply_signal(get_properties()); });
+    [=] { m_apply_signal(); });
   button_group_widget->connect_apply_to_all_signal(
-    [=] { m_apply_all_signal(get_properties()); });
+    [=] { m_apply_all_signal(); });
   button_group_widget->connect_cancel_signal([=] { reject(); });
   button_group_widget->connect_ok_signal([=] { accept(); });
   button_group_widget->connect_save_as_default_signal(
-    [=] { m_save_default_signal(get_properties()); });
+    [=] { m_save_default_signal(); });
   Window::layout()->addWidget(body);
 }
 

--- a/Applications/Spire/Source/BookView/BookViewPropertiesDialog.cpp
+++ b/Applications/Spire/Source/BookView/BookViewPropertiesDialog.cpp
@@ -85,8 +85,7 @@ BookViewPropertiesDialog::BookViewPropertiesDialog(
     &BookViewPropertiesDialog::on_tab_bar_clicked);
   auto button_group_widget = new PropertiesWindowButtonsWidget(this);
   layout->addWidget(button_group_widget);
-  button_group_widget->connect_apply_signal(
-    [=] { m_apply_signal(); });
+  button_group_widget->connect_apply_signal([=] { m_apply_signal(); });
   button_group_widget->connect_apply_to_all_signal(
     [=] { m_apply_all_signal(); });
   button_group_widget->connect_cancel_signal([=] { reject(); });

--- a/Applications/Spire/Source/BookView/BookViewWindow.cpp
+++ b/Applications/Spire/Source/BookView/BookViewWindow.cpp
@@ -131,7 +131,7 @@ void BookViewWindow::show_context_menu(const QPoint& pos) {
 void BookViewWindow::show_properties_dialog() {
   BookViewPropertiesDialog dialog(get_properties(), Security(), this);
   m_dialog_apply_connection = dialog.connect_apply_signal(
-    [=, &dialog] { set_properties(dialog.get_properties()); });
+    [&] { set_properties(dialog.get_properties()); });
   m_security_widget->show_overlay_widget();
   if(dialog.exec() == QDialog::Accepted) {
     set_properties(dialog.get_properties());

--- a/Applications/Spire/Source/BookView/BookViewWindow.cpp
+++ b/Applications/Spire/Source/BookView/BookViewWindow.cpp
@@ -131,7 +131,7 @@ void BookViewWindow::show_context_menu(const QPoint& pos) {
 void BookViewWindow::show_properties_dialog() {
   BookViewPropertiesDialog dialog(get_properties(), Security(), this);
   m_dialog_apply_connection = dialog.connect_apply_signal(
-    [=] (auto p) { set_properties(p); });
+    [=, &dialog] { set_properties(dialog.get_properties()); });
   m_security_widget->show_overlay_widget();
   if(dialog.exec() == QDialog::Accepted) {
     set_properties(dialog.get_properties());

--- a/Applications/Spire/Source/BookView/BookViewWindow.cpp
+++ b/Applications/Spire/Source/BookView/BookViewWindow.cpp
@@ -103,7 +103,7 @@ void BookViewWindow::show_context_menu(const QPoint& pos) {
   context_menu.addAction(&properties_action);
   context_menu.setFixedSize(scale(140, 28));
   context_menu.setWindowFlag(Qt::NoDropShadowWindowHint);
-  DropShadow context_menu_shadow(true, true, &context_menu);
+  auto context_menu_shadow = new DropShadow(true, true, &context_menu);
   context_menu.setStyleSheet(QString(R"(
     QMenu {
       background-color: #FFFFFF;

--- a/Applications/Spire/Source/KeyBindings/KeyBindingsWindow.cpp
+++ b/Applications/Spire/Source/KeyBindings/KeyBindingsWindow.cpp
@@ -1,0 +1,18 @@
+#include "Spire/KeyBindings/KeyBindingsWindow.hpp"
+
+using namespace boost::signals2;
+using namespace Spire;
+
+KeyBindingsWindow::KeyBindingsWindow(const KeyBindings& key_bindings,
+  QWidget* parent)
+  : Window(parent),
+    m_key_bindings(key_bindings) {}
+
+const KeyBindings& KeyBindingsWindow::get_key_bindings() const {
+  return m_key_bindings;
+}
+
+connection KeyBindingsWindow::connect_apply_signal(
+    const ApplySignal::slot_type& slot) const {
+  return scoped_connection();
+}

--- a/Applications/Spire/Source/TimeAndSales/TimeAndSalesPropertiesDialog.cpp
+++ b/Applications/Spire/Source/TimeAndSales/TimeAndSalesPropertiesDialog.cpp
@@ -183,10 +183,8 @@ TimeAndSalesPropertiesDialog::TimeAndSalesPropertiesDialog(
   auto buttons_widget = new PropertiesWindowButtonsWidget(this);
   buttons_widget->connect_save_as_default_signal(
     [=] { m_save_default_signal(); });
-  buttons_widget->connect_apply_to_all_signal(
-    [=] { m_apply_all_signal(); });
-  buttons_widget->connect_apply_signal(
-    [=] { m_apply_signal(); });
+  buttons_widget->connect_apply_to_all_signal([=] { m_apply_all_signal(); });
+  buttons_widget->connect_apply_signal([=] { m_apply_signal(); });
   buttons_widget->connect_ok_signal([=] { accept(); });
   buttons_widget->connect_cancel_signal([=] { reject(); });
   buttons_layout->addWidget(buttons_widget);

--- a/Applications/Spire/Source/TimeAndSales/TimeAndSalesPropertiesDialog.cpp
+++ b/Applications/Spire/Source/TimeAndSales/TimeAndSalesPropertiesDialog.cpp
@@ -182,11 +182,11 @@ TimeAndSalesPropertiesDialog::TimeAndSalesPropertiesDialog(
   buttons_layout->setSpacing(0);
   auto buttons_widget = new PropertiesWindowButtonsWidget(this);
   buttons_widget->connect_save_as_default_signal(
-    [=] { m_save_default_signal(get_properties()); });
+    [=] { m_save_default_signal(); });
   buttons_widget->connect_apply_to_all_signal(
-    [=] { m_apply_all_signal(get_properties()); });
+    [=] { m_apply_all_signal(); });
   buttons_widget->connect_apply_signal(
-    [=] { m_apply_signal(get_properties()); });
+    [=] { m_apply_signal(); });
   buttons_widget->connect_ok_signal([=] { accept(); });
   buttons_widget->connect_cancel_signal([=] { reject(); });
   buttons_layout->addWidget(buttons_widget);

--- a/Applications/Spire/Source/TimeAndSales/TimeAndSalesWindow.cpp
+++ b/Applications/Spire/Source/TimeAndSales/TimeAndSalesWindow.cpp
@@ -165,8 +165,8 @@ void TimeAndSalesWindow::export_table() {
 void TimeAndSalesWindow::show_properties_dialog() {
   TimeAndSalesPropertiesDialog dialog(m_properties, this);
   dialog.connect_apply_signal([=, &dialog] {
-      set_properties(dialog.get_properties());
-    });
+    set_properties(dialog.get_properties());
+  });
   m_security_widget->show_overlay_widget();
   if(dialog.exec() == QDialog::Accepted) {
     set_properties(dialog.get_properties());

--- a/Applications/Spire/Source/TimeAndSales/TimeAndSalesWindow.cpp
+++ b/Applications/Spire/Source/TimeAndSales/TimeAndSalesWindow.cpp
@@ -114,7 +114,7 @@ void TimeAndSalesWindow::contextMenuEvent(QContextMenuEvent* event) {
     context_menu.addAction(&export_action);
     context_menu.setFixedWidth(scale_width(140));
     context_menu.setWindowFlag(Qt::NoDropShadowWindowHint);
-    DropShadow context_menu_shadow(true, true, &context_menu);
+    auto context_menu_shadow = new DropShadow(true, true, &context_menu);
     context_menu.setStyleSheet(QString(R"(
       QMenu {
         background-color: #FFFFFF;

--- a/Applications/Spire/Source/TimeAndSales/TimeAndSalesWindow.cpp
+++ b/Applications/Spire/Source/TimeAndSales/TimeAndSalesWindow.cpp
@@ -164,7 +164,9 @@ void TimeAndSalesWindow::export_table() {
 
 void TimeAndSalesWindow::show_properties_dialog() {
   TimeAndSalesPropertiesDialog dialog(m_properties, this);
-  dialog.connect_apply_signal([=] (auto p) { set_properties(p); });
+  dialog.connect_apply_signal([=, &dialog] {
+      set_properties(dialog.get_properties());
+    });
   m_security_widget->show_overlay_widget();
   if(dialog.exec() == QDialog::Accepted) {
     set_properties(dialog.get_properties());

--- a/Applications/Spire/Source/TimeAndSales/TimeAndSalesWindow.cpp
+++ b/Applications/Spire/Source/TimeAndSales/TimeAndSalesWindow.cpp
@@ -164,9 +164,7 @@ void TimeAndSalesWindow::export_table() {
 
 void TimeAndSalesWindow::show_properties_dialog() {
   TimeAndSalesPropertiesDialog dialog(m_properties, this);
-  dialog.connect_apply_signal([=, &dialog] {
-    set_properties(dialog.get_properties());
-  });
+  dialog.connect_apply_signal([&] {set_properties(dialog.get_properties()); });
   m_security_widget->show_overlay_widget();
   if(dialog.exec() == QDialog::Accepted) {
     set_properties(dialog.get_properties());


### PR DESCRIPTION
I put the book view and time and sales demos in the drafts/demos folder called 'XYUpdatedSignals' to prove they function correctly.

Returning '{}' from get_key_bindings() gives me a warning about returning a local object by reference, so I added the m_key_bindings member to get it to compile. This member probably won't be in the actual implementation.